### PR TITLE
Added a "hover" attribute to each view.

### DIFF
--- a/build/framer.js
+++ b/build/framer.js
@@ -2663,6 +2663,22 @@ require.define("/src/views/view.coffee",function(require,module,exports,__dirnam
       }
     });
 
+    View.define("hover", {
+      get: function() {
+        return this._hover;
+      },
+      set: function(value) {
+        this._hover = value;
+        if (value === true) {
+          this.style.cursor = "pointer";
+        }
+        if (value === false) {
+          this.style.cursor = "auto";
+        }
+        return this.emit("change:hover");
+      }
+    });
+
     View.define("visible", {
       get: function() {
         return this._visible || true;
@@ -2926,7 +2942,8 @@ require.define("/src/views/view.coffee",function(require,module,exports,__dirnam
     "class": "",
     superView: null,
     visible: true,
-    index: 0
+    index: 0,
+    hover: false
   });
 
   View.Views = [];


### PR DESCRIPTION
By setting it to "true", the view's css cursor attribute is set to "pointer". By default, it's set to false.

I found that having a hover state is really useful in conveying affordance in a prototype, and having to type:

> PSD.Group.style.cursor = "pointer"

for every clickable view gets pretty wordy.
