### PR TITLE
Fixed Draggable on Safari and mobile Safari

### DIFF
--- a/src/ui/draggable.coffee
+++ b/src/ui/draggable.coffee
@@ -75,7 +75,7 @@ class exports.Draggable extends EventEmitter
 			t: event.timeStamp
 
 		@view.x = @_start.x + correctedDelta.x - @_offset.x
- 		@view.y = @_start.y + correctedDelta.y - @_offset.y
+		@view.y = @_start.y + correctedDelta.y - @_offset.y
 
 		@_deltas.push correctedDelta
 


### PR DESCRIPTION
webkitMovementX and webkitMovementY are not currently supported in the version of webkit that ships with Safari (OS X 10.9.2) and mobile Safari (iOS 7.1).

Reverted the position delta tracking (as seen in this commit https://github.com/jimray/Framer/commit/5fce26486cf2149e5a9c1027e0b5fccd2c7cb04f ) to the manual calculation instead of relying on the webkitMovement properties.
