### PR TITLE
Pass layer and state name into dynamic state properties

### DIFF
--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -5,21 +5,21 @@
 LayerStatesIgnoredKeys = ["ignoreEvents"]
 
 class exports.LayerStates extends EventEmitter
-	
+
 	constructor: (@layer) ->
-		
+
 		@_states = {}
 		@_orderedStates = []
-		
+
 		@animationOptions =
 			curve: "spring"
-		
+
 		# Always add the default state as the current
 		@add "default", @layer.properties
 
 		@_currentState = "default"
 		@_previousStates = []
-	
+
 	add: (stateName, properties) ->
 
 		# We also allow an object with states to be passed in
@@ -37,24 +37,24 @@ class exports.LayerStates extends EventEmitter
 		@_states[stateName] = properties
 
 	remove: (stateName) ->
-		
+
 		if not @_states.hasOwnProperty stateName
 			return
-		
+
 		delete @_states[stateName]
 		@_orderedStates = _.without @_orderedStates, stateName
-	
+
 	switch: (stateName, animationOptions) ->
-		
+
 		# Switches to a specific state. If animationOptions are
 		# given use those, otherwise the default options.
-		
+
 		if stateName is @_currentState
 			return
 
 		if not @_states.hasOwnProperty stateName
 			throw Error "No such state: '#{stateName}'"
-		
+
 		@emit "willSwitch", @_currentState, stateName, @
 
 		@_previousStates.push @_currentState
@@ -62,7 +62,7 @@ class exports.LayerStates extends EventEmitter
 
 		animationOptions ?= @animationOptions
 		animationOptions.properties = {}
-		
+
 		animatingKeys = @animatingKeys()
 
 		for k, v of @_states[stateName]
@@ -75,15 +75,15 @@ class exports.LayerStates extends EventEmitter
 				continue
 
 			# Allow dynamic properties as functions
-			v = v() if _.isFunction(v)
-			
+			v = v.call(@layer, @layer, stateName) if _.isFunction(v)
+
 			animationOptions.properties[k] = v
-			
+
 		animation = @layer.animate animationOptions
 
 		animation.on "stop", =>
 			@emit "didSwitch", _.last @_previousStates, stateName, @
-	
+
 	switchInstant: (stateName) ->
 		# Instantly switch to this new state
 		@switch stateName,
@@ -112,14 +112,13 @@ class exports.LayerStates extends EventEmitter
 	next:  ->
 		# TODO: maybe add animationOptions
 		states = Utils.arrayFromArguments arguments
-		
+
 		if not states.length
 			states = @states()
-		
+
 		@switch Utils.arrayNext(states, @_currentState)
 
 
 	last: (animationOptions) ->
 		# Return to last state
 		@switch _.last(@_previousStates), animationOptions
-


### PR DESCRIPTION
Also changes the context of the executed function to the layer.
This makes it possible to do things like:

```
# this adds a state called "a" for every layer that moves the layer 200px up from its current position
for layer in [layer1, layer2]
  layer.states.add 'a', y: -> @y - 200
```

or, if not relying on `this`:

```
for layer in [layer1, layer2]
  layer.states.add 'a', y: (l) -> l.y - 200
```
