### PR TITLE
Support for relative values in animation/state properties

### DIFF
--- a/test/tests/LayerAnimationTest.coffee
+++ b/test/tests/LayerAnimationTest.coffee
@@ -49,6 +49,41 @@ describe "LayerAnimation", ->
 					layer[p].should.equal 100
 					done()
 
+			it "should animate property #{p} with positive offset from current value", (done) ->
+
+				layer = new Layer()
+				layer[p] = 50
+
+				properties = {}
+				properties[p] = '+=50'
+
+				layer.animate
+					properties: properties
+					curve: "linear"
+					time: AnimationTime
+
+				layer.on "end", ->
+					layer[p].should.equal 100
+					done()
+
+			it "should animate property #{p} with negative offset from current value", (done) ->
+
+				layer = new Layer()
+				layer[p] = 50
+
+				properties = {}
+				properties[p] = '+=50'
+
+				layer.animate
+					properties: properties
+					curve: "linear"
+					time: AnimationTime
+
+				layer.on "end", ->
+					layer[p].should.equal 100
+					done()
+
+
 	describe "Basic", ->
 
 		it "should stop", (done) ->


### PR DESCRIPTION
So you can do things like:

``` coffeescript
layer.animate
    properties:
        x: '+=50'
        opacity: '-=0.1'
```

This also adds support for taking in strings with units as property values, e.g. `50px`. The units will be disregarded since we don't do anything with them at the moment, but we might in the future.

All tests pass and I've added new ones for the relative properties.
