### PR TITLE
Reuse function in LayerDraggable.TouchMove

### DIFF
--- a/framer/Animation.coffee
+++ b/framer/Animation.coffee
@@ -40,7 +40,7 @@ _runningAnimations = []
 # Todo: this would normally be BaseClass but the properties keyword
 # is not compatible and causes problems.
 class exports.Animation extends EventEmitter
-
+	@globalTimeScale: 1
 	@runningAnimations = ->
 		_runningAnimations
 
@@ -59,6 +59,8 @@ class exports.Animation extends EventEmitter
 			repeat: 0
 			delay: 0
 			debug: false
+
+		@options.time = @options.time * Animation.globalTimeScale
 
 		if options.origin
 			console.warn "Animation.origin: please use layer.originX and layer.originY"

--- a/framer/LayerDraggable.coffee
+++ b/framer/LayerDraggable.coffee
@@ -116,8 +116,8 @@ class exports.LayerDraggable extends EventEmitter
 
 
 		# We use the requestAnimationFrame to update the position
-		@nextX = newX
-		@nextY = newY
+		@_nextX = newX
+		@_nextY = newY
 		window.requestAnimationFrame @_setLayerPositions
 
 		@_deltas.push correctedDelta
@@ -125,8 +125,8 @@ class exports.LayerDraggable extends EventEmitter
 		@emit Events.DragMove, event
 
 	_setLayerPositions: () =>
-		@layer.x = @nextX
-		@layer.y = @nextY
+		@layer.x = @_nextX
+		@layer.y = @_nextY
 
 	_touchStart: (event) =>
 

--- a/framer/LayerDraggable.coffee
+++ b/framer/LayerDraggable.coffee
@@ -116,13 +116,17 @@ class exports.LayerDraggable extends EventEmitter
 
 
 		# We use the requestAnimationFrame to update the position
-		window.requestAnimationFrame =>
-			@layer.x = newX
-			@layer.y = newY
+		@nextX = newX
+		@nextY = newY
+		window.requestAnimationFrame @_setLayerPositions
 
 		@_deltas.push correctedDelta
 
 		@emit Events.DragMove, event
+
+	_setLayerPositions: () =>
+		@layer.x = @nextX
+		@layer.y = @nextY
 
 	_touchStart: (event) =>
 


### PR DESCRIPTION
This might be an unnecessary optimization but it seems like it could hurt performance to create a new anonymous function in every frame of TouchMove.