### PR TITLE
LayerStates.switch() returns the animation object

### DIFF
--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -103,6 +103,8 @@ class exports.LayerStates extends BaseClass
 			@_animation.on "stop", => 
 				@emit Events.StateDidSwitch, _.last(@_previousStates), stateName, @
 
+			@_animation
+
 
 	switchInstant: (stateName) ->
 		@switch stateName, null, true


### PR DESCRIPTION
A use case for this change:
```coffee
animation = layer1.switch("default")
animation.on 'end', ->
    # do some stuff
    otherLayer.visible = false
```