### PR TITLE
layer.states.add "newState", width: 500, didEnter: () -> alert("OMG!")

### DIFF
--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -43,10 +43,19 @@ class exports.LayerStates extends BaseClass
 		# Add a state with a name and properties
 		@_orderedStates.push stateName
 
-		if properties['enter'] || properties['exit']
+		if properties['didEnter'] || properties['didExit']
 			@on Events.StateDidSwitch, (oldState, newState) =>
-				properties['enter']?.call(@layer) if newState == stateName
-				properties['exit']?.call(@layer) if oldState == stateName
+				if newState == stateName
+					properties['didEnter']?.call(@layer)
+				if oldState == stateName
+					properties['didExit']?.call(@layer)
+
+		if properties['willEnter'] || properties['willExit']
+			@on Events.StateWillSwitch, (oldState, newState) =>
+				if newState == stateName
+					properties['willEnter']?.call(@layer)
+				if oldState == stateName
+					properties['willExit']?.call(@layer)				
 
 		@_states[stateName] = properties
 

--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -42,6 +42,12 @@ class exports.LayerStates extends BaseClass
 
 		# Add a state with a name and properties
 		@_orderedStates.push stateName
+
+		if properties['enter'] || properties['exit']
+			@on Events.StateDidSwitch, (oldState, newState) =>
+				properties['enter']?.call(@layer) if newState == stateName
+				properties['exit']?.call(@layer) if oldState == stateName
+
 		@_states[stateName] = properties
 
 	remove: (stateName) ->

--- a/test/tests/LayerStatesTest.coffee
+++ b/test/tests/LayerStatesTest.coffee
@@ -51,7 +51,31 @@ describe "LayerStates", ->
 
 			Framer.resetDefaults()
 
+	describe "Hooks", ->
 
+		it "should add didSwitch for enter: on .add", (done) ->
+			layer = new Layer
+			layer.states.animationOptions.time = 0.001
+			layer.states.add "new", x: 100, enter: () -> 
+				@x = 110
+			layer.states.on Events.StateDidSwitch, ->
+				layer.x.should.equal 110
+			layer.states.switch "new"
+			done()
+
+		it "should add didSwitch for exit: on .add", (done) ->
+			layer = new Layer
+			layer.states.animationOptions.time = 0.001
+
+			layer.states.add "original", x: 100, exit: () -> 
+				layer.x = 110
+			layer.states.switchInstant "original"
+
+			layer.states.add "new", x: 1
+			layer.states.on Events.StateDidSwitch, ->
+				layer.x.should.equal 110
+			layer.states.switch "new"
+			done()
 
 	describe "Switch", ->
 

--- a/test/tests/LayerStatesTest.coffee
+++ b/test/tests/LayerStatesTest.coffee
@@ -53,28 +53,26 @@ describe "LayerStates", ->
 
 	describe "Hooks", ->
 
-		it "should add didSwitch for enter: on .add", (done) ->
-			layer = new Layer
-			layer.states.animationOptions.time = 0.001
-			layer.states.add "new", x: 100, enter: () -> 
-				@x = 110
-			layer.states.on Events.StateDidSwitch, ->
-				layer.x.should.equal 110
-			layer.states.switch "new"
+		beforeEach ->
+			@layer = new Layer
+			@layer.states.animationOptions.time = 0.001
+
+		it "should handle a didEnter option", (done) ->
+			
+			@layer.states.add "new", x: 100, didEnter: () -> @x = 110
+			@layer.states.on Events.StateDidSwitch, => 
+				@layer.x.should.equal 110
+			@layer.states.switch "new"
 			done()
 
-		it "should add didSwitch for exit: on .add", (done) ->
-			layer = new Layer
-			layer.states.animationOptions.time = 0.001
-
-			layer.states.add "original", x: 100, exit: () -> 
-				layer.x = 110
-			layer.states.switchInstant "original"
-
-			layer.states.add "new", x: 1
-			layer.states.on Events.StateDidSwitch, ->
-				layer.x.should.equal 110
-			layer.states.switch "new"
+		it "should handle a didExit option", (done) ->
+			
+			@layer.states.add "original", x: 100, didExit: () -> @x = 110
+			@layer.states.switchInstant "original"
+			@layer.states.add "new", x: 1
+			@layer.states.on Events.StateDidSwitch, =>
+				@layer.x.should.equal 110
+			@layer.states.switch "new"
 			done()
 
 	describe "Switch", ->

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -350,8 +350,6 @@ describe "Layer", ->
 
 			layer.on "click", "tap", handler
 
-			console.log layer._eventListeners
-
 			layer.emit "click"
 			layer.emit "tap"
 


### PR DESCRIPTION
Added some didEnter / willEnter / didExit / willExit events for layer state changes, which you can add when you create the states. Yay!

In future it'd also be cool to be able to set didEnter on an already-created state.
