### PR TITLE
make icon link work on case-sensitive file systems

### DIFF
--- a/templates/Project/app.js
+++ b/templates/Project/app.js
@@ -2,7 +2,7 @@
 
 // This is just demo code. Feel free to delete it all.
 
-imageLayer = new Layer({x:0, y:0, width:128, height:128, image:"images/icon.png"})
+imageLayer = new Layer({x:0, y:0, width:128, height:128, image:"images/Icon.png"})
 imageLayer.center()
 
 // Define a set of states with names (the original state is 'default')


### PR DESCRIPTION
Linux (often) uses a case insensitive file system. Linking to "icon.png" but having an "Icon.png" results in a 404. Mac and Windows both use case-insensitive file systems so you don't notice it there.