### PR TITLE
Improved scrolling and dragging with physics simulations

### DIFF
--- a/framer/Animation.coffee
+++ b/framer/Animation.coffee
@@ -169,6 +169,9 @@ class exports.Animation extends EventEmitter
 		# Also emit this to the layer with self as argument
 		@options.layer.emit(event, @)
 
+	animatingProperties: ->
+		_.keys(@_stateA)
+
 	_start: =>
 		@options.layer._context._animationList.push(@)
 		@emit("start")

--- a/framer/Animators/SpringRK4Animator.coffee
+++ b/framer/Animators/SpringRK4Animator.coffee
@@ -1,6 +1,7 @@
 Utils = require "../Utils"
 
 {Animator} = require "../Animator"
+{Integrator} = require "../Integrator"
 
 class exports.SpringRK4Animator extends Animator
 
@@ -18,6 +19,9 @@ class exports.SpringRK4Animator extends Animator
 		@_velocity = @options.velocity
 		@_stopSpring = false
 
+		@_integrator = new Integrator (state) =>
+			return - @options.tension * state.x - @options.friction * state.v
+
 	next: (delta) ->
 
 		if @finished()
@@ -31,11 +35,9 @@ class exports.SpringRK4Animator extends Animator
 		# Calculate previous state
 		stateBefore.x = @_value - 1
 		stateBefore.v = @_velocity
-		stateBefore.tension = @options.tension
-		stateBefore.friction = @options.friction
 		
 		# Calculate new state
-		stateAfter = springIntegrateState stateBefore, delta
+		stateAfter = @_integrator.integrateState stateBefore, delta
 		@_value = 1 + stateAfter.x
 		finalVelocity = stateAfter.v
 		netFloat = stateAfter.x
@@ -52,45 +54,3 @@ class exports.SpringRK4Animator extends Animator
 
 	finished: =>
 		@_stopSpring
-
-
-springAccelerationForState = (state) ->
-	return - state.tension * state.x - state.friction * state.v
-
-springEvaluateState = (initialState) ->
-
-	output = {}
-	output.dx = initialState.v
-	output.dv = springAccelerationForState initialState
-
-	return output
-
-springEvaluateStateWithDerivative = (initialState, dt, derivative) ->
-
-	state = {}
-	state.x = initialState.x + derivative.dx * dt
-	state.v = initialState.v + derivative.dv * dt
-	state.tension = initialState.tension
-	state.friction = initialState.friction
-
-	output = {}
-	output.dx = state.v
-	output.dv = springAccelerationForState state
-
-	return output
-
-springIntegrateState = (state, speed) ->
-
-	a = springEvaluateState state
-	b = springEvaluateStateWithDerivative state, speed * 0.5, a
-	c = springEvaluateStateWithDerivative state, speed * 0.5, b
-	d = springEvaluateStateWithDerivative state, speed, c
-
-	dxdt = 1.0/6.0 * (a.dx + 2.0 * (b.dx + c.dx) + d.dx)
-	dvdt = 1.0/6.0 * (a.dv + 2.0 * (b.dv + c.dv) + d.dv)
-
-	state.x = state.x + dxdt * speed
-	state.v = state.v + dvdt * speed
-
-	return state
-

--- a/framer/Framer.coffee
+++ b/framer/Framer.coffee
@@ -28,6 +28,7 @@ Framer.LinearAnimator = (require "./Animators/LinearAnimator").LinearAnimator
 Framer.BezierCurveAnimator = (require "./Animators/BezierCurveAnimator").BezierCurveAnimator
 Framer.SpringDHOAnimator = (require "./Animators/SpringDHOAnimator").SpringDHOAnimator
 Framer.SpringRK4Animator = (require "./Animators/SpringRK4Animator").SpringRK4Animator
+Framer.LayerDraggable = (require "./LayerDraggable").LayerDraggable
 Framer.Importer = (require "./Importer").Importer
 Framer.DeviceView = (require "./DeviceView").DeviceView
 Framer.Debug = (require "./Debug").Debug

--- a/framer/Integrator.coffee
+++ b/framer/Integrator.coffee
@@ -1,0 +1,53 @@
+
+Utils = require "./Utils"
+
+{Config} = require "./Config"
+
+class exports.Integrator
+
+  """
+  Usage:
+    - Instantiate with a function that takes (state) -> acceleration
+    - Call integrateState with state={x, v} and delta
+  """
+
+  constructor: (@_accelerationForState) ->
+    
+    if ! _.isFunction @_accelerationForState
+      console.warn "Integrator: an integrator must be constructed with an acceleration function"
+      @_accelerationForState = -> 0
+
+  integrateState: (state, dt) ->
+
+    a = @_evaluateState state
+    b = @_evaluateStateWithDerivative state, dt * 0.5, a
+    c = @_evaluateStateWithDerivative state, dt * 0.5, b
+    d = @_evaluateStateWithDerivative state, dt, c
+
+    dxdt = 1.0/6.0 * (a.dx + 2.0 * (b.dx + c.dx) + d.dx)
+    dvdt = 1.0/6.0 * (a.dv + 2.0 * (b.dv + c.dv) + d.dv)
+
+    state.x = state.x + dxdt * dt
+    state.v = state.v + dvdt * dt
+
+    return state
+
+  _evaluateState: (initialState) ->
+
+    output = {}
+    output.dx = initialState.v
+    output.dv = @_accelerationForState initialState
+
+    return output
+
+  _evaluateStateWithDerivative: (initialState, dt, derivative) ->
+
+    state = {}
+    state.x = initialState.x + derivative.dx * dt
+    state.v = initialState.v + derivative.dv * dt
+
+    output = {}
+    output.dx = state.v
+    output.dv = @_accelerationForState state
+
+    return output

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -652,7 +652,7 @@ class exports.Layer extends BaseClass
 		properties = {}
 
 		for animation in @animations()
-			for propertyName in _.keys(animation._stateA)
+			for propertyName in animation.animatingProperties()
 				properties[propertyName] = animation
 
 		return properties

--- a/framer/LayerDraggable.coffee
+++ b/framer/LayerDraggable.coffee
@@ -1,13 +1,17 @@
 {_} = require "./Underscore"
 
 Utils = require "./Utils"
-{EventEmitter} = require "./EventEmitter"
+{BaseClass} = require "./BaseClass"
 {Events} = require "./Events"
+{Frame} = require "./Frame"
+{Simulation} = require "./Simulation"
 
 # Add specific events for draggable
 Events.DragStart = "dragstart"
 Events.DragMove = "dragmove"
 Events.DragEnd = "dragend"
+
+Events.DirectionLock = "directionLock"
 
 """
 This takes any layer and makes it draggable by the user on mobile or desktop.
@@ -21,11 +25,22 @@ Some interesting things are:
 
 """
 
-class exports.LayerDraggable extends EventEmitter
+class exports.LayerDraggable extends BaseClass
 
 	@VelocityTimeOut = 100
+	@VelocityMultiplier = 890
+	@DragThreshold = 10
+	@OverscrollScale = 0.5
+	@SimulationModelOptions =
+		scrollFriction: 2.1
+		scrollTolerance: 1/10
+		springFriction: 40
+		springTension: 200
+		springTolerance: 1/10000
 
 	constructor: (@layer) ->
+
+		super
 
 		@_deltas = []
 		@_isDragging = false
@@ -34,15 +49,160 @@ class exports.LayerDraggable extends EventEmitter
 		@speedX = 1.0
 		@speedY = 1.0
 		
-		@maxDragFrame = null
+		@_maxDragFrame = null
+		@_inertialScroll = false
 
-		# @resistancePointX = null
-		# @resistancePointY = null
-		# @resistanceDistance = null
+		@_xAxisLock = false
+		@_yAxisLock = false
+		@_directionIsLocked = false
+		@_propagateEvents = false
 
 		@attach()
 
-	attach: -> @layer.on  Events.TouchStart, @_touchStart
+	@define "overscroll", @simpleProperty "overscroll", null, true
+
+	@define "directionLock", @simpleProperty "directionLock", false, true
+
+	@define "multipleDraggables", @simpleProperty "multipleDraggables", false, true
+
+	##############################################################
+	# Scroll bounds
+
+	@define "maxDragFrame",
+		get: -> @_maxDragFrame
+		set: (value) ->
+			if _.isFunction(value)
+				@_maxDragFrame = value
+			else
+				@_maxDragFrame = new Frame value
+				
+			@_updateInertialScrollBounds() if @_inertialScroll
+
+	_scrollBounds: =>
+		maxDragFrame = _.result(@, 'maxDragFrame')
+		if maxDragFrame
+			dragFrame =
+				minX: maxDragFrame.minX
+				minY: maxDragFrame.minY
+				maxX: maxDragFrame.maxX - @layer.width
+				maxY: maxDragFrame.maxY - @layer.height
+		else
+			# TODO: A bit of a hack for unconstrained scrolling. Fine for now, as
+			# all the maxDragFrame-related methods will likely be rewritten.
+			dragFrame = 
+				minX: -Infinity
+				minY: -Infinity
+				maxX: Infinity
+				maxY: Infinity
+		return dragFrame
+
+	_clamp: (value, min, max) ->
+		value = min if value < min
+		value = max if value > max
+		return value
+
+	_clampAndScalePastBounds: (value, min, max, scale) ->
+		value = min + (value - min) * scale if value < min
+		value = max + (value - max) * scale if value > max
+		return value
+
+	_constrainPositionToBounds: (position, bounds, scale) ->
+		{minX, maxX, minY, maxY} = bounds
+
+		newPosition = {}
+
+		if @overscroll
+			newPosition.x = @_clampAndScalePastBounds position.x, minX, maxX, scale
+			newPosition.y = @_clampAndScalePastBounds position.y, minY, maxY, scale
+		else
+			newPosition.x = @_clamp position.x, minX, maxX
+			newPosition.y = @_clamp position.y, minY, maxY
+
+		return newPosition 
+
+	# A convenience property for getting scrolling behavior from LayerDraggable.
+	# The layer will pan around within the frame passed.
+	# 
+	# If the layer dimensions are smaller then the frame passed, the layer will
+	# not move at all (unless overscroll is on, in which case the layer will
+	# move, but spring back to 0 when dragging has finished).
+	@define "maxScrollFrame",
+		get: ->
+			throw Error """You can only assign to maxScrollFrame, which computes a new 
+			maxDragFrame. Try accessing maxDragFrame instead."""
+		set: (value) ->
+			layerWidthTooSmall = @layer.width < value.width
+			layerHeightTooSmall = @layer.height < value.height
+
+			if layerWidthTooSmall
+				x = 0
+				width = @layer.width
+			else
+				x = - @layer.width + value.width
+				width = @layer.width * 2 - value.width
+
+			if layerHeightTooSmall
+				y = 0
+				height = @layer.height
+			else
+				y = - @layer.height + value.height
+				height = @layer.height * 2 - value.height
+
+			@maxDragFrame = {x, y, width, height}
+
+	##############################################################
+	# Velocity
+
+	# Take the "average" velocity over the last 100 milliseconds
+	_calculateDraggingVelocity: ->
+
+		earliestValidTime = Date.now() - @constructor.VelocityTimeOut
+		deltas = _.filter @_deltas, (delta) =>
+			delta.t > earliestValidTime
+
+		if deltas.length < 2
+			return {x:0, y:0}		
+
+		curr = deltas[deltas.length - 1]
+		prev = deltas[0]
+		time = curr.t - prev.t
+
+		velocity =
+			x: (curr.x - prev.x) / time
+			y: (curr.y - prev.y) / time
+
+		velocity.x = 0 if velocity.x is Infinity
+		velocity.y = 0 if velocity.y is Infinity
+
+		if @directionLock
+			velocity.x = 0 if ! @_xAxisLock
+			velocity.y = 0 if ! @_yAxisLock
+
+		return velocity
+
+	_calculateInertialScrollingVelocity: ->
+
+		xFinished = @_simulationX.finished()
+		yFinished = @_simulationY.finished()
+
+		correctedVelocity = {x:0, y:0}
+		correctedVelocity.x = (@_simulationX.getState().v / @constructor.VelocityMultiplier) if ! xFinished
+		correctedVelocity.y = (@_simulationY.getState().v / @constructor.VelocityMultiplier) if ! yFinished
+
+		return correctedVelocity
+
+	calculateVelocity: ->
+		if @_isDragging
+			return @_calculateDraggingVelocity()
+		else if @_inertialScroll
+			return @_calculateInertialScrollingVelocity()
+		else
+			return {x:0, y:0}
+
+	##############################################################
+	# Event Handling
+
+	attach: -> @layer.on	Events.TouchStart, @_touchStart
 	remove: -> @layer.off Events.TouchStart, @_touchStart
 
 	emit: (eventName, event) ->
@@ -52,35 +212,33 @@ class exports.LayerDraggable extends EventEmitter
 
 		super eventName, event
 
+	_updateDirectionLock: (correctedDelta) ->
+		
+		@_xAxisLock = Math.abs(correctedDelta.x) > @constructor.DragThreshold
+		@_yAxisLock = Math.abs(correctedDelta.y) > @constructor.DragThreshold
+		
+		xSlightlyPreferred = Math.abs(correctedDelta.x) > @constructor.DragThreshold / 2
+		ySlightlyPreferred = Math.abs(correctedDelta.y) > @constructor.DragThreshold / 2
+		
+		# Allow locking in both directions at the same time
+		@_xAxisLock = @_yAxisLock = true if (xSlightlyPreferred && ySlightlyPreferred)
 
-	calculateVelocity: ->
+		if @_xAxisLock || @_yAxisLock
 
-		if @_deltas.length < 2
-			return {x:0, y:0}
+			@_directionIsLocked = true
 
-		curr = @_deltas[-1..-1][0]
-		prev = @_deltas[-2..-2][0]
-		time = curr.t - prev.t
+			@emit Events.DirectionLock, 
+				x: @_xAxisLock
+				y: @_yAxisLock
 
-		# Bail out if the last move updates where a while ago
-		timeSinceLastMove = (new Date().getTime() - prev.t)
-
-		if timeSinceLastMove > @VelocityTimeOut
-			return {x:0, y:0}
-
-		velocity =
-			x: (curr.x - prev.x) / time
-			y: (curr.y - prev.y) / time
-
-		velocity.x = 0 if velocity.x is Infinity
-		velocity.y = 0 if velocity.y is Infinity
-
-		velocity
+			@_propagateEvents = false if @multipleDraggables
 
 	_updatePosition: (event) =>
 
-		if @enabled is false
-			return
+		event.preventDefault()
+		event.stopPropagation() if ! @_propagateEvents
+
+		return if ! @enabled
 
 		@emit Events.DragMove, event
 
@@ -97,26 +255,22 @@ class exports.LayerDraggable extends EventEmitter
 			t: event.timeStamp
 
 		# Pixel align all moves
-		newX = parseInt(@_start.x + correctedDelta.x - @_offset.x)
-		newY = parseInt(@_start.y + correctedDelta.y - @_offset.y)
+		@_position.x = parseInt(@_start.x + correctedDelta.x - @_offset.x)
+		@_position.y = parseInt(@_start.y + correctedDelta.y - @_offset.y)
 
 		if @maxDragFrame
+			# TODO: Should we realign to pixel first?
+			@_position = @_constrainPositionToBounds(@_position, 
+				@_scrollBounds(), @constructor.OverscrollScale)
 
-			maxDragFrame = @maxDragFrame
-			maxDragFrame = maxDragFrame() if _.isFunction(maxDragFrame)
-
-			minX = Utils.frameGetMinX(maxDragFrame)
-			maxX = Utils.frameGetMaxX(maxDragFrame) - @layer.width
-			minY = Utils.frameGetMinY(maxDragFrame)
-			maxY = Utils.frameGetMaxY(maxDragFrame) - @layer.height
-
-			newX = minX if newX < minX
-			newX = maxX if newX > maxX
-			newY = minY if newY < minY
-			newY = maxY if newY > maxY
-
-		@layer.x = newX
-		@layer.y = newY
+		if @directionLock
+			@_updateDirectionLock(correctedDelta) if ! @_directionIsLocked
+			
+			@layer.x = @_position.x if @_xAxisLock
+			@layer.y = @_position.y if @_yAxisLock	
+		else
+			@layer.x = @_position.x
+			@layer.y = @_position.y
 
 		@_deltas.push correctedDelta
 
@@ -124,9 +278,25 @@ class exports.LayerDraggable extends EventEmitter
 
 	_touchStart: (event) =>
 
+		@_propagateEvents = true if (@multipleDraggables && @directionLock)
+
+		event.preventDefault()
+		event.stopPropagation() if ! @_propagateEvents
+
 		@layer.animateStop()
 
 		@_isDragging = true
+		@_directionIsLocked = false
+		@_xAxisLock = false
+		@_yAxisLock = false
+
+		@_position =
+			x: @layer.x
+			y: @layer.y
+		
+		if @overscroll
+			@_position = @_constrainPositionToBounds(@_position, 
+				@_scrollBounds(), (1 / @constructor.OverscrollScale))
 
 		touchEvent = Events.touchEvent event
 
@@ -135,8 +305,8 @@ class exports.LayerDraggable extends EventEmitter
 			y: touchEvent.clientY
 
 		@_offset =
-			x: touchEvent.clientX - @layer.x
-			y: touchEvent.clientY - @layer.y
+			x: touchEvent.clientX - @_position.x
+			y: touchEvent.clientY - @_position.y
 
 		@_screenScale =
 			x: @layer.screenScaleX()
@@ -149,11 +319,91 @@ class exports.LayerDraggable extends EventEmitter
 
 	_touchEnd: (event) =>
 
-		@_isDragging = false
-
 		document.removeEventListener Events.TouchMove, @_updatePosition
 		document.removeEventListener Events.TouchEnd, @_touchEnd
 
+		# Start the simulation prior to emitting the DragEnd event.
+		# This way, if the user calls layer.animate on DragEnd, the simulation will 
+		# be canceled by the user's animation (if the user animates x and/or y).
+		@_startSimulation() if @inertialScroll
+
 		@emit Events.DragEnd, event
 
-		@_deltas = []
+		# Set _isDragging after DragEnd is fired, so that calls to calculateVelocity() 
+		# still returns dragging velocity - both in case the user calls calculateVelocity(),
+		# (which would return a stale value before the simulation had finished one tick)
+		# and because @_startSimulation currently calls calculateVelocity().
+		@_isDragging = false
+
+		@_deltas.length = 0
+
+	##############################################################
+	# Inertial scroll simulation
+
+	@define "inertialScroll",
+		get: ->
+			@_inertialScroll
+		set: (value) ->
+			@_inertialScroll = value
+			if @_inertialScroll
+
+				# Most likely, inertial scroll is coupled with overscroll, so turn
+				# overscroll on unless it was explicitly turned off prior to this
+				@overscroll ?= true
+
+				@_simulationX ?= new Simulation
+					layer: @layer
+					properties: {x: true}
+					model: "inertial-scroll"
+					modelOptions: @constructor.SimulationModelOptions
+				@_simulationY ?= new Simulation
+					layer: @layer
+					properties: {y: true}
+					model: "inertial-scroll"
+					modelOptions: @constructor.SimulationModelOptions
+
+				# TODO: pixel align moves?
+				@_simulationX.on Events.SimulationStep, (state) =>
+					if @overscroll
+						@layer.x = state.x
+					else
+						{minX, maxX} = @_scrollBounds()
+						@layer.x = @_clamp state.x, minX, maxX
+
+				@_simulationY.on Events.SimulationStep, (state) => 
+					if @overscroll
+						@layer.y = state.x
+					else
+						{minY, maxY} = @_scrollBounds()
+						@layer.y = @_clamp state.x, minY, maxY
+
+				@_updateInertialScrollBounds()
+				@_startSimulation()
+			else
+				@_simulationX?.off Events.SimulationStep
+				@_simulationY?.off Events.SimulationStep
+				@_stopSimulation()
+
+	_updateInertialScrollBounds: ->
+		{minX, maxX, minY, maxY} = @_scrollBounds()
+
+		@_simulationX.setOptions {min: minX, max: maxX}
+		@_simulationY.setOptions {min: minY, max: maxY}
+
+	_startSimulation: ->
+		velocity = @calculateVelocity()
+
+		@_simulationY.start()
+		@_simulationY.setState
+			x: @layer.y
+			v: velocity.y * @constructor.VelocityMultiplier
+
+		@_simulationX.start()
+		@_simulationX.setState
+			x: @layer.x
+			v: velocity.x * @constructor.VelocityMultiplier
+
+	_stopSimulation: =>
+		@_simulationX?.stop()
+		@_simulationY?.stop()
+

--- a/framer/Simulation.coffee
+++ b/framer/Simulation.coffee
@@ -1,0 +1,121 @@
+{_} = require "./Underscore"
+
+Utils = require "./Utils"
+
+{Config} = require "./Config"
+{Defaults} = require "./Defaults"
+{EventEmitter} = require "./EventEmitter"
+{Events} = require "./Events"
+
+{SpringSimulator} = require "./Simulators/SpringSimulator"
+{FrictionSimulator} = require "./Simulators/FrictionSimulator"
+{InertialScrollSimulator} = require "./Simulators/InertialScrollSimulator"
+
+Events.SimulationStart = 'simulationStart'
+Events.SimulationStep = 'simulationStep'
+Events.SimulationStop = 'simulationStop'
+
+SimulatorClasses =
+	"spring": SpringSimulator
+	"friction": FrictionSimulator
+	"inertial-scroll": InertialScrollSimulator
+
+class exports.Simulation extends EventEmitter
+
+	constructor: (options={}) ->
+
+		# options = Defaults.getDefaults "Simulation", options
+
+		super options
+
+		@options = Utils.setDefaultProperties options,
+			layer: null
+			properties: {}
+			model: "spring"
+			modelOptions: {}
+			delay: 0
+			debug: false
+
+		@_running = false
+
+		SimulatorClass = SimulatorClasses[@options.model] or SpringSimulator
+
+		@_simulator = new SimulatorClass @options.modelOptions
+
+	# Though properties aren't modified directly by the simulation, it's still
+	# necessary to return them so that conflicting animations/simulations can
+	# detect one another and not run at the same time.
+	animatingProperties: ->
+		_.keys(@options.properties)
+
+	start: =>
+
+		if @options.layer is null
+			console.error "Simulation: missing layer"
+
+		if @options.debug
+			console.log "Simulation.start #{@_simulator.constructor.name}", @options.modelOptions
+
+		animatingProperties = @animatingProperties()
+		for property, animation of @options.layer.animatingProperties()
+			if property in animatingProperties
+				animation.stop()
+
+		if @options.delay
+			Utils.delay(@options.delay, @_start)
+		else
+			@_start()
+
+		return true
+
+	stop: (emit=true)->
+		return if ! @_running
+
+		@_running = false
+		
+		@options.layer._context._animationList = _.without(
+			@options.layer._context._animationList, @)
+
+		@emit(Events.SimulationStop) if emit
+		Framer.Loop.off("update", @_update)
+
+	copy: -> return new Simulation(_.clone(@options))
+
+	emit: (event) ->
+		super
+		# Also emit this to the layer with self as argument
+		@options.layer.emit(event, @)
+
+	_start: =>
+		return if @_running
+
+		@_running = true
+
+		@options.layer._context._animationList.push(@)
+
+		@emit(Events.SimulationStart)
+		Framer.Loop.on("update", @_update)
+
+	_update: (delta) =>
+		if @_simulator.finished()
+			@stop(emit=false)
+			@emit("end")
+			@emit(Events.SimulationStop)
+		else
+			result = @_simulator.next(delta)
+			@emit(Events.SimulationStep, result, delta)
+
+	##############################################################
+	# Passthrough to simulator
+
+	getState: ->
+		return @_simulator.getState()
+
+	setState: (state) ->
+		@_simulator.setState(state)
+
+	setOptions: (options) ->
+		@_simulator.setOptions(options)
+
+	finished: ->
+		return @_simulator.finished()

--- a/framer/Simulator.coffee
+++ b/framer/Simulator.coffee
@@ -1,0 +1,40 @@
+Utils = require "./Utils"
+
+{Config} = require "./Config"
+
+class exports.Simulator
+
+  """
+  The simulator class runs a physics simulation based on a set of input values 
+  at setup({input values}), and emits an output state {x, v}
+  """
+  
+  constructor: (options={}) ->
+    @_state = {x:0, v:0}
+    @options = null
+    @setup options
+
+  setup: (options) ->
+    throw Error "Not implemented"
+
+  next: (delta) ->
+    throw Error "Not implemented"
+
+  finished: ->
+    throw Error "Not implemented"
+
+  # Assume the caller may change the state object, so best to clone it.
+  setState: (state) ->
+    @_state =
+      x: state.x
+      v: state.v
+
+  getState: ->
+    state =
+      x: @_state.x
+      v: @_state.v
+    return state
+
+  setOptions: (options={}) ->
+    for k, v of options
+      @options[k] = v

--- a/framer/Simulators/FrictionSimulator.coffee
+++ b/framer/Simulators/FrictionSimulator.coffee
@@ -1,0 +1,33 @@
+
+Utils = require "../Utils"
+
+{Simulator} = require "../Simulator"
+{Integrator} = require "../Integrator"
+
+class exports.FrictionSimulator extends Simulator
+
+	setup: (options) ->
+
+		@options = Utils.setDefaultProperties options,
+			friction: 2
+			velocity: 0
+			position: 0
+			tolerance: 1/10
+
+		@_state =
+			x: @options.position
+			v: @options.velocity
+
+		@_integrator = new Integrator (state) =>
+			return - (@options.friction * state.v)
+
+	next: (delta) ->
+		
+		@_state = @_integrator.integrateState(@_state, delta)
+
+		return @_state
+
+	finished: =>
+		
+		Math.abs(@_state.v) < @options.tolerance
+

--- a/framer/Simulators/InertialScrollSimulator.coffee
+++ b/framer/Simulators/InertialScrollSimulator.coffee
@@ -1,0 +1,167 @@
+
+Utils = require "../Utils"
+
+{Simulator} = require "../Simulator"
+
+{SpringSimulator} = require "./SpringSimulator"
+{FrictionSimulator} = require "./FrictionSimulator"
+
+class exports.InertialScrollSimulator extends Simulator
+
+	setup: (options) ->
+
+		@options = Utils.setDefaultProperties options,
+			scrollFriction: 2.1
+			scrollTolerance: 1/10
+			springFriction: 40
+			springTension: 200
+			springTolerance: 1/10000
+			velocity: 0
+			position: 0
+			min: 0
+			max: 0
+
+		@_frictionSimulator = new FrictionSimulator
+			friction: @options.scrollFriction
+			tolerance: @options.scrollTolerance
+			velocity: @options.velocity
+			position: @options.position
+
+		@_springSimulator = new SpringSimulator
+			tension: @options.springTension
+			friction: @options.springFriction
+			tolerance: @options.springTolerance
+			velocity: @options.velocity
+			position: @options.position
+
+		@_state =
+			x: @options.position
+			v: @options.velocity
+
+		@_useSpring = false
+
+	next: (delta) ->
+
+		if @_useSpring
+			@_state = @_springSimulator.next(delta)
+		else
+			@_state = @_frictionSimulator.next(delta)
+			@_tryTransitionToSpring(@_state)
+
+		return @_state
+
+	finished: =>
+
+		if @_useSpring
+		  @_springSimulator.finished()
+		else
+		  @_frictionSimulator.finished()
+
+	setState: (state) ->
+
+		@_state = 
+			x: state.x
+			v: state.v
+
+		@_frictionSimulator.setState(@_state)
+		
+		if @_isValidState()
+			@_tryTransitionToSpring()
+		else
+			bound = @options.min if @_state.x <= @options.min
+			bound = @options.max if @_state.x >= @options.max
+			@_transitionToSpring(bound)
+
+	# If the position is outside the min and max bounds, and traveling
+	# further away, then transition from friction to spring simulation
+	_tryTransitionToSpring: (force) ->
+
+		belowMinWithVelocity = @_state.x < @options.min && @_state.v <= 0
+		aboveMaxWithVelocity = @_state.x > @options.max && @_state.v >= 0
+		
+		if (belowMinWithVelocity || aboveMaxWithVelocity)
+			bound = @options.min if belowMinWithVelocity
+			bound = @options.max if aboveMaxWithVelocity
+			@_transitionToSpring(bound)
+		else
+			@_useSpring = false
+
+	_transitionToSpring: (bound) ->
+		@_useSpring = true
+		@_springSimulator.options.offset = bound
+		@_springSimulator.setState(@_state)
+
+	# If the position is outside the min and max bounds, but traveling
+	# back towards the bounds, check if the velocity is sufficient to
+	# carry the position back within bounds. If it is, let friction do the
+	# work. If not, the state is invalid, so use the spring.
+	_isValidState: ->
+
+		# Note that if velocity is 0, the state is still valid (should use spring, 
+		# not friction), and we don't want to divide by 0 later in the check.
+		belowMinTravelingBack = @_state.x < @options.min && @_state.v > 0
+		aboveMaxTravelingBack = @_state.x > @options.max && @_state.v < 0
+		
+		check = false
+
+		if (belowMinTravelingBack)
+			bound = @options.min
+			check = true
+		else if (aboveMaxTravelingBack)
+			bound = @options.max
+			check = true
+
+		if check
+			friction = @_frictionSimulator.options.friction
+			solution = 1 - (friction * (bound - @_state.x)) / @_state.v
+
+			return solution > 0
+
+		return true
+
+	# The math behind _isValidState:
+	# 
+	# 1. Integrate the friction simulator's acceleration to find velocity
+	# 
+	#         a = - k * v
+	#     dv/dt = - k * v
+	# Int(dv/v) = - k * Int(dt)
+	#      ln v = - k * t + C
+	# 
+	# => Solve for C at t = 0
+	# 
+	# ln v(0) = - k * 0 + C
+	# ln v(0) = C
+	# 
+	# => Plug C back into v(t)
+	# 
+	#     ln v = - k * t + ln v(0)
+	# e^(ln v) = e^(- k * t) + e^(ln v(0))
+	#        v = v(0) * e^(- k * t)
+	# 
+	# 2. Integrate velocity to find position
+	# 
+	# Int(v) = v(0) * Int(e^(- k * t))
+	#      x = - v(0) * e^(-k * t) / k + C
+	# 
+	# => Solve for C at t = 0
+	# 
+	#            x(0) = - v(0) * e^(-k * 0) / k + C
+	#            x(0) = - v(0) / k + C
+	# x(0) + v(0) / k = C
+	# 
+	# => Plug C back into x(t)
+	# 
+	# x = - v(0) * e^(-k * t) / k + x(0) + v(0) / k
+	# 
+	# 3. Check if a (real) solution exists for t for position x
+	# 
+	#                                x = - v(0) * e^(-k * t) / k + x(0) + v(0) / k
+	#                         x - x(0) = - v(0) * e^(-k * t) / k + v(0) / k
+	#                   k * (x - x(0)) = - v(0) * e^(-k * t) + v(0)
+	#            k * (x - x(0)) - v(0) = - v(0) * e^(-k * t)
+	# (k * (x - x(0)) - v(0)) / - v(0) = e^(-k * t)
+	#       1 - (k * (x - x(0)) / v(0) = e^(-k * t)
+	#   ln(1 - (k * (x - x(0)) / v(0)) = -k * t
+	# 
+	# Therefore, a real solution exists if 1 - (k * (x - x(0)) / v(0) > 0

--- a/framer/Simulators/SpringSimulator.coffee
+++ b/framer/Simulators/SpringSimulator.coffee
@@ -1,0 +1,53 @@
+Utils = require "../Utils"
+
+{Simulator} = require "../Simulator"
+{Integrator} = require "../Integrator"
+
+class exports.SpringSimulator extends Simulator
+
+	setup: (options) ->
+
+		@options = Utils.setDefaultProperties options,
+			tension: 500
+			friction: 10
+			tolerance: 1/10000
+			velocity: 0
+			position: 0
+			offset: 0
+			
+		@_state =
+			x: @options.position
+			v: @options.velocity
+
+		@_integrator = new Integrator (state) =>
+			return - @options.tension * state.x - @options.friction * state.v
+
+	next: (delta) ->
+
+		@_state = @_integrator.integrateState(@_state, delta)
+		
+		return @getState()
+
+	finished: =>
+
+		positionNearZero = Math.abs(@_state.x) < @options.tolerance
+		velocityNearZero = Math.abs(@_state.v) < @options.tolerance
+
+		positionNearZero && velocityNearZero
+	
+	# Internally, the spring always rests at state.x == 0. However, since it's a 
+	# common use case to rest at a non-zero position, offset is automatically
+	# applied to position for convenience when interfacing with the outside world.
+	setState: (state) ->
+
+		@_state = 
+			x: state.x - @options.offset
+			v: state.v
+
+	getState: ->
+
+		state =
+			x: @_state.x + @options.offset
+			v: @_state.v
+
+		return state


### PR DESCRIPTION
Physics-based scrolling. Here we go!

Demos here:

* [Draggable rows in a scrollview](https://db.tt/dYLF2AmP)
* [Crop a photo](https://db.tt/XlOGXQvL)
* [Fling an object](https://db.tt/bJqVil5A)

Demo source [here](https://github.com/dabbott/FramerScrollPhysicsDemos)

tl;dr: It's a hard problem. This is a first draft that works decently, but there are a lot of other ways we could implement this, and it really comes down to Framer's direction.

#### My priorities for this first pass:

1. Scrolling should feel 100% accurate
2. It should be simple to use
3. The math should be straightforward enough that anyone can read and maintain the code
4. Modify existing stuff as little as possible. Don't break Framer

Given that the new [priority list](https://github.com/koenbok/Framer/wiki/Contributing:-Wanted-Features) includes event handling and a physics engine, I could imagine waiting on those two to improve scrolling, as they're really the building blocks. Nonetheless, if we do decide to build some of these components ourselves, I outline some of the challenges and possible solutions below.

#### 1. Scrolling should feel 100% accurate

However we go about it, scrolling has to feel perfect. It's one of the keys to making mobile prototypes feel native.

My first attempt was something along the lines of [ScrollViewBest](http://cl.ly/083x3h3Y0E15), using the existing Animators. The reasons why this doesn't work: 

* for the spring, the "scale" of the motion is determined by the initial and end positions stored in `Animation._stateA` and `Animation._stateB`. By that I mean, igit stf you start a spring animation with `velocity = 100` and final position `y = 0`, the result will be vastly different depending on whether the view starts at postiion `y = 5` versus `y = 5000`.

* an animation from 0 to 1 is really not the easiest way to represent friction. You could have a FrictionAnimator, but you would have to determine the end position of the view completely independently from the actual animation. You would also have to make sure either velocity or friction was set automatically, or there's a chance the animator would stop short.

You could solve this by modifying Animation. Letting animators do more than just animate from 0 to 1 should solve these problems (an unbounded animation for friction, 0 to N for spring). However, then you would have a variety of different behaviors that Animation would have to deal with, which isn't the intended usage of the existing class.

Instead, I solved this by adding a concept of physical Simulators. These are really just a generalized version of Animators. I avoided touching Animators for now (goal 4, don't break Framer), but building Animators on top of a more general physics engine should be fairly easy.

The physics credit really goes to Ralph at [iamralpht.github.io/physics/](iamralpht.github.io/physics/), as I pretty much just implement the Spring + Friction as described. The main difference - I used numerical integration instead of symbolic integration, since the math is much more straightforward (goal 3, simple math). The only place I include any interesting math is the `IntertialScrollSimulator._isValidState()` method, and I provide a step-by-step explanation, which can be checked for correctness.

#### 2. It should be simple to use

I could imagine having improved scrolling either be part of Layer or LayerDraggable (or both):

* Layer has `scroll`, `scrollHorizontal`, `scrollVertical`, and `scrollFrame`. As a Framer user, I would probably assume these are what I want to use. It takes a reasonably good understanding of what these really do and what their limitations are to understand when I should use LayerDraggable instead.

* LayerDraggable has touch event handling and velocity calculation. I like how easy to is to apply a "draggable" interaction to any layer. I could imagine doing "pinchable" or "rotatable" in a similar way. I like that if inertial scroll is part of LayerDraggable, it is more general, and I can use it for interactions other than scrolling e.g. flinging an object. However, *because* "dragging" is much more general than "scrolling", I hesitate to couple something somewhat view-hierarchy-dependent like a "scrollFrame" with LayerDraggable. And I don't want to introduce yet another scrolling concept with `LayerScrollable extends LayerDraggable`.

* Maybe there's an even better option?

Ultimately I went with LayerDraggable. I don't enforce a parent/sublayer relationship, so any view is "scrollable" within any other view (which is actually quite convenient...). 

The main properties:

* `draggable.inertialScroll` - the layer keeps moving after you let go. This starts the physics simulation. `draggable.speedX|Y` work as expected, and can be used to prevent dragging in a direction.
* `draggable.overscroll` - the layer drags with resistance past the edges, and will spring back if inertialScroll is true. Get a more Androidy feel by turning inertialScroll on by overscroll off.
* `draggable.directionLock` - scrolling can lock in a direction.. same as iOS. The implementation: the drag must move `DragThreshold = 10px` before the layer begins to move. Locking can occur in X or Y, or both if the drag moves more than `DragThreshold / 2 = 5px` in both directions.
* `draggable.multipleDraggables` - propagate touch events until directionLock (very hacky)

I didn't want to break anything, so I kept `maxDragFrame` and added a new, equally confusing concept `maxScrollFrame`, which is a helper to set up your `maxDragFrame`. `maxDragFrame` works acceptably for dragging a small layer within a large one, but it's super hard to figure out the proper `maxDragFrame` for scrolling a large layer within a smaller one. While these are two distinct use cases, they're both confusing, and I'd like to merge them somehow.

`directionLock` is a bit of an afterthought to be honest, and should *really* go wherever we put event handling stuff. The DragThreshold should probably scale by deviceScale, and may need to take the velocity of the view into account (since we generally swipe in arcs that go quite a bit horizontal and will trigger a false positive). As a user, I would also wonder why I can't use `directionLock` on Layer itself if I use `scroll`.

The `multipleDraggables` thing is an afterthought tacked on to the `directionLock` afterthought. Having to manually turn on/off certain draggables is pretty terrible and I'm sure we can do much better. Perhaps a single layer in a group can obtain ownership over events for that group, or similar.

Other stuff I'd want to improve:

* There are too many physics constants being passed around
* Defaults for iOS and Android
* Tests

#### 3. The math should be straightforward enough that anyone can read and maintain the code

The reasons I would support writing the physics code ourselves, or perhaps making physics a plugin, versus integrating an existing library into Framer core:

* Physics libraries are big and include a lot of complicated stuff that we don't need. Framer's existing dependencies (lodash, EventEmitter3) are not at all like that. Lodash is a defacto standard that doesn't require additional learning. EventEmitter3 has roughly the standard EventEmitter API and is only ~200 lines.

* Physics libraries are built for high performance with millions of objects in the simulation. Which totally isn't the Framer use case. So the code is *generally* more convoluted and we wouldn't even get the benefit of it. (I don't know how frequently developers/users would have to wade through physics engine code... maybe we're not concerned about this point)

* Part of Framer's beauty is that the codebase is so small and written with clarity as a key goal. The current event handling and animators in Framer are written in a clear, consistent style and super easy to understand. Building a tiny physics engine ourselves lets us keep that consistent style where it really matters.

But I'm biased since I already wrote some code :) I also don't have much experience using the various .js-based physics engines, so I can't speak too much to their complexity.

Anyway, I pulled out the RK4 integrator we already have into a separate class that's shared between the spring Animator and spring/friction Simulators.

My code isn't optimized for performance in any way... lots of unnecessary object creation that would be easy to get rid of without hurting clarity much. Would also need to look into why the simulation blows up under stress.

#### 4. Modify existing stuff as little as possible. Don't break Framer

(minor) existing things I changed:

* I changed how velocity is calculated - based on the average dragging speed over the last 100ms instead of between the last two events. In the end I'm not sure it makes much of a difference. This feels more accurate to me, but maybe that's just me. I could probably acheive the same feel with the previous method and slightly different constants. (also there's a [minor bug in the existing code](https://github.com/koenbok/Framer/blob/e5ce332acba6fe2436c33c7f2b48c95559671a11/framer/LayerDraggable.coffee#L68), as @VelocityTimeOut does not refer to the constructor here)

* I added an `animatingProperties` method to Animation, so that Animations and Simulations can play nice in a layer's `animationList`. The right way for these two to play nice everywhere would probably be a BaseAnimation class which Animations and Simulations extend, or merge Animations and physics Simulations as mentioned above.

* SpringRK4Animator now uses the Integrator class. If we keep this spring class, is could be cleaned up a ton - or just wrap an instance of SpringSimulator with `@_offset = -1`.

#### Next steps

Where do you folks think these pieces fit? If we do actually go with any of what I have here, we would have to improve the API a lot. What changes do you suggest?

Pull in a physics engine engine and get that for free, or write a simpler, more compatible version ourselves?

Pull in an event handling library and get that for free, or write a simpler, more layer-centric version ourselves? Is Framer moving toward WebGL rendering? If so, would we have to maintain a DOM event handling library and our own WebGL event handling library that propagates events via Layers?

Or defer the physics/event library decisions and go with something along these lines for now?
