### PR TITLE
Allow base64-encoded image 'paths'

### DIFF
--- a/framer/Importer.coffee
+++ b/framer/Importer.coffee
@@ -22,7 +22,7 @@ class exports.Importer
 
 		layersByName = {}
 		layerInfo = @_loadlayerInfo()
-		
+
 		# Pass one. Create all layers build the hierarchy
 		layerInfo.map (layerItemInfo) =>
 			@_createLayer layerItemInfo
@@ -43,7 +43,7 @@ class exports.Importer
 	_loadlayerInfo: ->
 
 		# Chrome is a pain in the ass and won't allow local file access
-		# therefore I add a .js file which adds the data to 
+		# therefore I add a .js file which adds the data to
 		# window.__imported__["<path>"]
 
 		importedKey = "#{@paths.documentName}/layers.json.js"
@@ -54,7 +54,7 @@ class exports.Importer
 		return Framer.Utils.domLoadJSONSync @paths.layerInfo
 
 	_createLayer: (info, superLayer) ->
-		
+
 		LayerClass = Layer
 
 		layerInfo =
@@ -70,13 +70,16 @@ class exports.Importer
 		# Most layers will have an image, add that here
 		if info.image
 			layerInfo.frame = info.image.frame
-			layerInfo.image = Utils.pathJoin @path, info.image.path
-			
+			if info.image.path.indexOf('data:image') != -1
+				layerInfo.image = Utils.pathJoin @path, info.image.path
+			else
+				layerInfo.image = @path
+
 		# If there is a mask on this layer group, take its frame
 		if info.maskFrame
 			layerInfo.frame = info.maskFrame
 			layerInfo.clip = true
-			
+
 		# Figure out what the super layer should be. If this layer has a contentLayer
 		# (like a scroll view) we attach it to that instead.
 		if superLayer?.contentLayer

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -16,10 +16,10 @@ layerValueTypeError = (name, value) ->
 	throw new Error("Layer.#{name}: value '#{value}' of type '#{typeof(value)}'' is not valid")
 
 layerProperty = (obj, name, cssProperty, fallback, validator, set) ->
-	result = 
+	result =
 		exportable: true
 		default: fallback
-		get: -> 
+		get: ->
 			@_properties[name]
 
 		set: (value) ->
@@ -113,10 +113,10 @@ class exports.Layer extends BaseClass
 	@define "opacity", layerProperty @, "opacity", "opacity", 1, _.isNumber
 	@define "index", layerProperty @, "index", "zIndex", 0, _.isNumber
 	@define "clip", layerProperty @, "clip", "overflow", true, _.isBool
-	
+
 	@define "scrollHorizontal", layerProperty @, "scrollHorizontal", "overflowX", false, _.isBool, (layer, value) ->
 		layer.ignoreEvents = false if value is true
-	
+
 	@define "scrollVertical", layerProperty @, "scrollVertical", "overflowY", false, _.isBool, (layer, value) ->
 		layer.ignoreEvents = false if value is true
 
@@ -193,7 +193,7 @@ class exports.Layer extends BaseClass
 	@define "name",
 		exportable: true
 		default: ""
-		get: -> 
+		get: ->
 			@_getPropertyValue "name"
 		set: (value) ->
 			@_setPropertyValue "name", value
@@ -207,7 +207,7 @@ class exports.Layer extends BaseClass
 	@define "borderRadius",
 		exportable: true
 		default: 0
-		get: -> 
+		get: ->
 			@_properties["borderRadius"]
 
 		set: (value) ->
@@ -229,7 +229,7 @@ class exports.Layer extends BaseClass
 			return if not point
 			for k in ["x", "y"]
 				@[k] = point[k] if point.hasOwnProperty(k)
-					
+
 
 	@define "frame",
 		get: -> _.pick(@, ["x", "y", "width", "height"])
@@ -300,11 +300,11 @@ class exports.Layer extends BaseClass
 	center: ->
 		@frame = @centerFrame() # Center  in superLayer
 		@
-	
+
 	centerX: (offset=0) ->
 		@x = @centerFrame().x + offset # Center x in superLayer
 		@
-	
+
 	centerY: (offset=0) ->
 		@y = @centerFrame().y + offset # Center y in superLayer
 		@
@@ -323,7 +323,7 @@ class exports.Layer extends BaseClass
 	# 	if @_superOrParentLayer()
 	# 		return @_superOrParentLayer().screenOriginX()
 	# 	return @originX
-	
+
 	# screenOriginY = ->
 	# 	if @_superOrParentLayer()
 	# 		return @_superOrParentLayer().screenOriginY()
@@ -347,11 +347,11 @@ class exports.Layer extends BaseClass
 			y: 0
 			width:  @width  * @screenScaleX()
 			height: @height * @screenScaleY()
-		
+
 		layers = @superLayers(context=true)
 		layers.push(@)
 		layers.reverse()
-		
+
 		for superLayer in layers
 			factorX = if superLayer._superOrParentLayer() then superLayer._superOrParentLayer().screenScaleX() else 1
 			factorY = if superLayer._superOrParentLayer() then superLayer._superOrParentLayer().screenScaleY() else 1
@@ -363,7 +363,7 @@ class exports.Layer extends BaseClass
 
 	scaledFrame: ->
 
-		# Get the scaled frame for a layer, taking into account 
+		# Get the scaled frame for a layer, taking into account
 		# the transform origins.
 
 		frame = @frame
@@ -374,7 +374,7 @@ class exports.Layer extends BaseClass
 		frame.height *= scaleY
 		frame.x += (1 - scaleX) * @originX * @width
 		frame.y += (1 - scaleY) * @originY * @height
-		
+
 		return frame
 
 	##############################################################
@@ -391,7 +391,7 @@ class exports.Layer extends BaseClass
 
 		getComputedStyle  = document.defaultView.getComputedStyle
 		getComputedStyle ?= window.getComputedStyle
-		
+
 		return getComputedStyle(@_element)
 
 	@define "classList",
@@ -439,7 +439,7 @@ class exports.Layer extends BaseClass
 	querySelectorAll: (query) -> @_element.querySelectorAll(query)
 
 	destroy: ->
-		
+
 		# Todo: check this
 
 		if @superLayer
@@ -447,7 +447,7 @@ class exports.Layer extends BaseClass
 
 		@_element.parentNode?.removeChild @_element
 		@removeAllListeners()
-		
+
 		@_context._layerList = _.without @_context._layerList, @
 
 		@_context.emit("layer:destroy", @)
@@ -513,7 +513,7 @@ class exports.Layer extends BaseClass
 
 			# If the file is local, we want to avoid caching
 			# if Utils.isLocal() and not (_.startsWith(imageUrl, "http://") or _.startsWith(imageUrl, "https://"))
-			if Utils.isLocal() and not imageUrl.match(/^https?:\/\//) and @_cacheImage is false
+			if Utils.isLocal() and not imageUrl.match(/^https?:\/\//) and @_cacheImage is false and imageUrl.indexOf('data:image') != -1
 				imageUrl += "?nocache=#{Date.now()}"
 
 			# As an optimization, we will only use a loader
@@ -731,7 +731,7 @@ class exports.Layer extends BaseClass
 
 	@define "scrollY",
 		get: -> @_element.scrollTop
-		set: (value) -> 
+		set: (value) ->
 			layerValueTypeError("scrollY", value) if not _.isNumber(value)
 			@_element.scrollTop = value
 
@@ -778,11 +778,11 @@ class exports.Layer extends BaseClass
 			listener = listener.modifiedListener
 
 		eventNames = [eventNames] if typeof eventNames == 'string'
-			
+
 		for eventName in eventNames
 			do (eventName) =>
 				super eventName, listener
-				
+
 				@_context.eventManager.wrap(@_element).removeEventListener(eventName, listener)
 
 				if @_eventListeners


### PR DESCRIPTION
This change allows base-64 encoded 'paths' to be placed in the JSON layer file, allowing single-page rendering of Framer prototypes.