### PR TITLE
Constructor options

### DIFF
--- a/framer/BaseClass.coffee
+++ b/framer/BaseClass.coffee
@@ -20,7 +20,7 @@ class exports.BaseClass extends EventEmitter
 
 		# See if we need to add this property to the internal properties class
 		if @ isnt BaseClass
-			descriptor.enumerable = descriptor.exportable == true
+			descriptor.enumerable = descriptor.enumerable || !descriptor.hasOwnProperty('enumerable')
 			descriptor.propertyName = propertyName
 
 			if not descriptor.excludeFromProps
@@ -44,19 +44,19 @@ class exports.BaseClass extends EventEmitter
 		# Define the property
 		Object.defineProperty(@prototype, propertyName, descriptor)
 
-	@simpleProperty = (name, fallback, exportable=true) ->
+	@simpleProperty = (name, fallback, enumerable=true) ->
 		# Default property, provides storage and fallback
-		exportable: exportable
+		enumerable: enumerable
 		default: fallback
 		get: -> @_getPropertyValue(name)
 		set: (value) -> @_setPropertyValue(name, value)
 
-	@proxyProperty = (keyPath, exportable=true) ->
+	@proxyProperty = (keyPath, enumerable=true) ->
 		# Allows to easily proxy properties from an instance object
 		# Object property is in the form of "object.property"
 		objectKey = keyPath.split(".")[0]
-		result = 
-			exportable: exportable
+		result =
+			enumerable: enumerable
 			get: ->
 				return unless @[objectKey]
 				Utils.getValueForKeyPath(@, keyPath)

--- a/framer/BaseClass.coffee
+++ b/framer/BaseClass.coffee
@@ -27,16 +27,12 @@ class exports.BaseClass extends EventEmitter
 				@[DefinedPropertiesKey] ?= {}
 				@[DefinedPropertiesKey][propertyName] = descriptor
 
-		# If no setter was given, this must be a readonly property (and there's a
-		# proper JS flag to signal that:
-		descriptor.writeable = !!descriptor.set
-
 		# Set the getter/setter as setProperty on this object so we can access and override it easily
 		getName = "get#{capitalizeFirstLetter(propertyName)}"
 		@::[getName] = descriptor.get
 		descriptor.get = @::[getName]
 
-		if descriptor.writeable
+		if descriptor.set
 			setName = "set#{capitalizeFirstLetter(propertyName)}"
 			@::[setName] = descriptor.set
 			descriptor.set = @::[setName]
@@ -122,7 +118,7 @@ class exports.BaseClass extends EventEmitter
 
 		# Set the default values for this object
 		for name, descriptor of @constructor[DefinedPropertiesKey]
-			if descriptor.writeable
+			if descriptor.set
 				initialValue = Utils.valueOrDefault(options?[name], @_getPropertyDefaultValue(name));
 				if not (initialValue in [null, undefined])
 					@[name] = initialValue

--- a/framer/BaseClass.coffee
+++ b/framer/BaseClass.coffee
@@ -23,8 +23,9 @@ class exports.BaseClass extends EventEmitter
 			descriptor.enumerable = descriptor.exportable == true
 			descriptor.propertyName = propertyName
 
-			@[DefinedPropertiesKey] ?= {}
-			@[DefinedPropertiesKey][propertyName] = descriptor
+			if not descriptor.excludeFromProps
+				@[DefinedPropertiesKey] ?= {}
+				@[DefinedPropertiesKey][propertyName] = descriptor
 
 		# If no setter was given, this must be a readonly property (and there's a
 		# proper JS flag to signal that:
@@ -79,14 +80,13 @@ class exports.BaseClass extends EventEmitter
 	keys: -> _.keys(@props)
 
 	@define "props",
+		excludeFromProps: true
 		get: ->
-			props = {}
-			console.log '---'
+			value = {}
 			for k, v of @constructor[DefinedPropertiesKey]
-				console.log k
-				props[k] = @[k]
+				value[k] = @[k]
 
-			props
+			value
 
 		set: (value) ->
 			for k, v of value

--- a/framer/Compat.coffee
+++ b/framer/Compat.coffee
@@ -4,7 +4,8 @@ compatWarning = (msg) ->
 	console.warn msg
 
 compatProperty = (name, originalName) ->
-	exportable: false
+	excludeFromProps: true
+	enumerable: false
 	get: -> 
 		compatWarning "#{originalName} is a deprecated property"
 		@[name]

--- a/framer/Components/ScrollComponent.coffee
+++ b/framer/Components/ScrollComponent.coffee
@@ -79,9 +79,6 @@ class exports.ScrollComponent extends Layer
 
 		super options
 
-		for k in ["contentInset", "scrollPoint", "scrollX", "scrollY", "scrollFrame", "mouseWheelEnabled"]
-			@[k] = options[k] if options.hasOwnProperty(k)
-
 		@_contentInset = Utils.zeroRect()
 
 		@setContentLayer(new Layer)

--- a/framer/Components/ScrollComponent.coffee
+++ b/framer/Components/ScrollComponent.coffee
@@ -61,6 +61,7 @@ class exports.ScrollComponent extends Layer
 	# scroll component to be draggable, but it's an easy mistake to make. If you 
 	# do want this, use a LayerDraggable directly.
 	@define "draggable",
+		excludeFromProps: true
 		get: -> throw Error("You likely want to use content.draggable")
 
 	@define "content",

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -692,6 +692,7 @@ class exports.Layer extends BaseClass
 	## STATES
 
 	@define "states",
+		excludeFromProps: true,
 		get: -> @_states ?= new LayerStates @
 
 	#############################################################################

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -73,10 +73,6 @@ class exports.Layer extends BaseClass
 		# We need to explicitly set the element id again, becuase it was made by the super
 		# @_element.id = "FramerLayer-#{@id}"
 
-		for k in ["minX", "midX", "maxX", "minY", "midY", "maxY"]
-			if options.hasOwnProperty(k)
-				@[k] = options[k]
-
 		# Insert the layer into the dom or the superLayer element
 		if not options.superLayer
 			@_insertElement() if not options.shadow

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -17,7 +17,6 @@ layerValueTypeError = (name, value) ->
 
 layerProperty = (obj, name, cssProperty, fallback, validator, set) ->
 	result = 
-		exportable: true
 		default: fallback
 		get: -> 
 			@_properties[name]
@@ -112,7 +111,6 @@ class exports.Layer extends BaseClass
 		layer.ignoreEvents = false if value is true
 
 	@define "scroll",
-		exportable: true
 		get: -> @scrollHorizontal is true or @scrollVertical is true
 		set: (value) -> @scrollHorizontal = @scrollVertical = value
 
@@ -182,7 +180,6 @@ class exports.Layer extends BaseClass
 	# Identity
 
 	@define "name",
-		exportable: true
 		default: ""
 		get: -> 
 			@_getPropertyValue "name"
@@ -196,7 +193,6 @@ class exports.Layer extends BaseClass
 	# Border radius compatibility
 
 	@define "borderRadius",
-		exportable: true
 		default: 0
 		get: -> 
 			@_properties["borderRadius"]
@@ -470,7 +466,6 @@ class exports.Layer extends BaseClass
 	## IMAGE
 
 	@define "image",
-		exportable: true
 		default: ""
 		get: ->
 			@_getPropertyValue "image"
@@ -535,7 +530,8 @@ class exports.Layer extends BaseClass
 	## HIERARCHY
 
 	@define "superLayer",
-		exportable: false
+		excludeFromProps: true
+		enumerable: false
 		get: ->
 			@_superLayer or null
 		set: (layer) ->
@@ -575,11 +571,13 @@ class exports.Layer extends BaseClass
 	# Let's make it when we need it.
 
 	@define "subLayers",
-		exportable: false
+		excludeFromProps: true
+		enumerable: false
 		get: -> _.clone @_subLayers
 
 	@define "siblingLayers",
-		exportable: false
+		excludeFromProps: true
+		enumerable: false
 		get: ->
 
 			# If there is no superLayer we need to walk through the root
@@ -654,7 +652,7 @@ class exports.Layer extends BaseClass
 		return properties
 
 	@define "isAnimating",
-		exportable: false
+		enumerable: false
 		get: -> @animations().length isnt 0
 
 	animateStop: ->

--- a/test/tests/BaseClassTest.coffee
+++ b/test/tests/BaseClassTest.coffee
@@ -147,3 +147,36 @@ describe "BaseClass", ->
 		testClass.testA = 200
 		testClass.poop.hello.should.equal 200
 
+	it "should exclude prop from props, when excludeFromProps is set", ->
+
+		class TestClass8 extends Framer.BaseClass
+			@define "testProp",
+				get: () -> "value"
+				excludeFromProps: true
+
+		instance = new TestClass8()
+		props = instance.props
+
+		props.hasOwnProperty("testProp").should.be.false
+
+		props = {}
+		for field of instance
+			props[field] = true
+
+		props.hasOwnProperty("testProp").should.be.true
+
+	it "should exclude prop from enumeration, when enumerable is lowered", ->
+
+		class TestClass8 extends Framer.BaseClass
+			@define "testProp",
+				get: () -> "value"
+				enumerable: false
+
+		instance = new TestClass8()
+		props = {}
+		for field of instance
+			props[field] = true
+
+		props.hasOwnProperty("testProp").should.be.false
+
+

--- a/test/tests/BaseClassTest.coffee
+++ b/test/tests/BaseClassTest.coffee
@@ -149,12 +149,12 @@ describe "BaseClass", ->
 
 	it "should exclude prop from props, when excludeFromProps is set", ->
 
-		class TestClass8 extends Framer.BaseClass
+		class TestClass extends Framer.BaseClass
 			@define "testProp",
 				get: () -> "value"
 				excludeFromProps: true
 
-		instance = new TestClass8()
+		instance = new TestClass()
 		props = instance.props
 
 		props.hasOwnProperty("testProp").should.be.false
@@ -167,16 +167,26 @@ describe "BaseClass", ->
 
 	it "should exclude prop from enumeration, when enumerable is lowered", ->
 
-		class TestClass8 extends Framer.BaseClass
+		class TestClass extends Framer.BaseClass
 			@define "testProp",
 				get: () -> "value"
 				enumerable: false
 
-		instance = new TestClass8()
+		instance = new TestClass()
 		props = {}
 		for field of instance
 			props[field] = true
 
 		props.hasOwnProperty("testProp").should.be.false
+
+	it "should throw on assignment of read-only prop", ->
+
+		class TestClass extends Framer.BaseClass
+			@define "testProp",
+				get: () -> "value"
+
+		instance = new TestClass()
+		(-> instance.testProp = "foo").should.throw "setting a property that has only a getter"
+
 
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -117,9 +117,9 @@ describe "Layer", ->
 			else
 				layer.style.webkitTransformOrigin.should.equal "50% 50%"
 
-		it "should set local image", ->
+		it.only "should set local image", ->
 	
-			imagePath = "static/test.png"			
+			imagePath = "../static/test.png"
 			layer = new Layer
 
 			layer.image = imagePath
@@ -135,17 +135,17 @@ describe "Layer", ->
 			layer.props.image.should.equal imagePath
 
 		it "should set image", ->
-			imagePath = "static/test.png"	
+			imagePath = "../static/test.png"
 			layer = new Layer image:imagePath
 			layer.image.should.equal imagePath
 
 		it "should unset image with null", ->
-			layer = new Layer image:"static/test.png"
+			layer = new Layer image:"../static/test.png"
 			layer.image = null
 			layer.image.should.equal ""
 
 		it "should unset image with empty string", ->
-			layer = new Layer image:"static/test.png"
+			layer = new Layer image:"../static/test.png"
 			layer.image = ""
 			layer.image.should.equal ""
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -117,22 +117,25 @@ describe "Layer", ->
 			else
 				layer.style.webkitTransformOrigin.should.equal "50% 50%"
 
-		it.only "should set local image", ->
+		it "should set local image", ->
 	
-			imagePath = "../static/test.png"
+			prefix = "../"
+			imagePath = "static/test.png"
+			fullPath = prefix + imagePath
 			layer = new Layer
 
-			layer.image = imagePath
-			layer.image.should.equal imagePath
+			layer.image = fullPath
+			layer.image.should.equal fullPath
 
 			layer.style["background-image"].indexOf(imagePath).should.not.equal(-1)
-			# layer.style["background-image"].should.match "file://"
-			# layer.style["background-image"].should.match "?nocache="
+			layer.style["background-image"].indexOf("file://").should.not.equal(-1)
+			layer.style["background-image"].indexOf("?nocache=").should.not.equal(-1)
 
-			layer.computedStyle()["background-size"].should.equal "cover"
-			layer.computedStyle()["background-repeat"].should.equal "no-repeat"
+			#layer.computedStyle()["background-size"].should.equal "cover"
+			#layer.computedStyle()["background-repeat"].should.equal "no-repeat"
 
-			layer.props.image.should.equal imagePath
+			image = layer.props.image
+			layer.props.image.should.equal fullPath
 
 		it "should set image", ->
 			imagePath = "../static/test.png"

--- a/test/tests/VideoLayerTest.coffee
+++ b/test/tests/VideoLayerTest.coffee
@@ -6,5 +6,5 @@ describe "VideoLayer", ->
 		if not Utils.isSafari()
 			it "should create video", ->
 							
-				videoLayer = new VideoLayer video:"static/test.mp4"
-				videoLayer.player.src.should.equal "static/test.mp4"
+				videoLayer = new VideoLayer video:"../static/test.mp4"
+				videoLayer.player.src.should.equal "../static/test.mp4"


### PR DESCRIPTION
Dropping `exportable` in favor of native `enumerable` flag, and a `excludeFromProps` flag:

All properties defined using `@define` will now be kept in the properties dictionary; that is - unless they have their `excludeFromProps` flag raised. This dictionary is also used to forward constructor options to the respective properties, and on copying layers.

The `enumerable` flag (`true` by default) determines whether the property is enumerable from the JavaScript perspective; so whether or not it should show up on using `for (var field in obj)`. 