### PR TITLE
Set correct index on scroll layer when using wrap

### DIFF
--- a/framer/Components/ScrollComponent.coffee
+++ b/framer/Components/ScrollComponent.coffee
@@ -406,5 +406,6 @@ class exports.ScrollComponent extends Layer
 			subLayer.index = subLayerIndex
 
 		scroll.superLayer = layer.superLayer
+		scroll.index = layer.index
 		layer.destroy()
 		return scroll


### PR DESCRIPTION
When wrapping a layer using the ScrollComponent, the new scroll component layer should be inserted at the same index as the original layer being wrapped.