### PR TITLE
Prevent page change in locked direction

### DIFF
--- a/framer/Components/PageComponent.coffee
+++ b/framer/Components/PageComponent.coffee
@@ -152,7 +152,9 @@ class exports.PageComponent extends ScrollComponent
 
 		# See if we meet the minimum velocity to scroll to the next page. If not we snap
 		# to the layer closest to the scroll point.
-		if Math.max(Math.abs(velocity.x), Math.abs(velocity.y)) < @velocityThreshold
+		if Math.max(Math.abs(velocity.x), Math.abs(velocity.y)) < @velocityThreshold or
+			(@content.draggable._directionLockEnabledX and (@direction == 'right' or @direction == 'left')) or
+			(@content.draggable._directionLockEnabledY and (@direction == 'down' or @direction == 'up'))
 			# print "velocity"
 			@snapToPage(@closestPage, true, @animationOptions)
 			return 


### PR DESCRIPTION
When using direction lock on page components, the component will successfully prevent you from dragging content in a locked direction, but if you are dragging your finger in the locked direction faster than the velocity threshold, when you release the page will still change to the next or previous page in the locked direction. This if statement makes sure that if that happens we just keep the user on the original page.