### PR TITLE
Fix subLayers being affected by superLayer `html`

### DIFF
--- a/framer/Config.coffee
+++ b/framer/Config.coffee
@@ -18,6 +18,8 @@ body {
 .framerLayer {
 	display: block;
 	position: absolute;
+	left: 0;
+	top: 0;
 	background-repeat: no-repeat;
 	background-size: cover;
 	-webkit-overflow-scrolling: touch;

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -838,6 +838,13 @@ describe "Layer", ->
 			layer._elementHTML.innerHTML.should.equal "Hello"
 			layer.ignoreEvents.should.equal true
 
+		it "should not effect subLayers", ->
+
+			layer = new Layer
+			layer.html = "Hello"
+			subLayer = new Layer superLayer: layer
+
+			subLayer._element.offsetTop.should.equal 0
 
 		it "should set interactive html and allow pointer events", ->
 


### PR DESCRIPTION
A sub-layer of a super-layer with `Layer#html` content set is not positioned correctly in the parent, as it is pushed down by the content. See [this example](http://share.framerjs.com/6ohd1s4lc4vl/).