### PR TITLE
Allow property setters to create sub-layers in construction

### DIFF
--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -47,8 +47,10 @@ class exports.Layer extends BaseClass
 
 	constructor: (options={}) ->
 
+		# Set needed private variables
 		@_properties = {}
 		@_style = {}
+		@_subLayers = []
 
 		# Special power setting for 2d rendering path. Only enable this
 		# if you know what you are doing. See LayerStyle for more info.
@@ -79,9 +81,6 @@ class exports.Layer extends BaseClass
 		# If an index was set, we would like to use that one
 		if options.hasOwnProperty("index")
 			@index = options.index
-
-		# Set needed private variables
-		@_subLayers = []
 
 		@_context.emit("layer:create", @)
 


### PR DESCRIPTION
If you had a property that wanted to handle the logic of instantiating sub-layers during construction, it would throw an error (`TypeError: undefined is not an object (evaluating 'layer._subLayers.push')`) because the `_subLayers` property is set after calling super's constructor.

Though rare, this pattern [is necessary](https://github.com/peteschaffner/framer-material/blob/master/app.coffee#L377) when you have a subclass that requires sub-layer(s) and that also needs to be able to set properties on said sub-layer(s) when instantiated.