### PR TITLE
Fix issue #236 - `Event.ImageLoaded` event never triggered in FramerJS + Fix issue #219 "PageComponent resets position of layer"

### DIFF
--- a/framer/Components/PageComponent.coffee
+++ b/framer/Components/PageComponent.coffee
@@ -98,7 +98,10 @@ class exports.PageComponent extends ScrollComponent
 			direction = "right"
 			throw new Error("#{direction} should be in #{directions}")
 
-		point = {x:0, y:0}
+		# For allowing pages added with 'addPage' to behave consistently with pages added 
+		# to the PageComponent using 'superLayer', keep the original page point
+		# so one of the two coordinates is left untouched after the page is added
+		point = page.point
 
 		if @content.subLayers.length
 			point.x = Utils.frameGetMaxX(@content.contentFrame()) if direction in ["right", "east"]

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -551,7 +551,7 @@ class exports.Layer extends BaseClass
 
 			# As an optimization, we will only use a loader
 			# if something is explicitly listening to the load event
-			if @events?.hasOwnProperty "load" or @events?.hasOwnProperty "error"
+			if @_eventListeners?.hasOwnProperty "load" or @_eventListeners?.hasOwnProperty "error"
 
 				loader = new Image()
 				loader.name = imageUrl


### PR DESCRIPTION
This PR targets issue #236: **`Event.ImageLoaded` event never triggered in FramerJS**

On the Layer class, the property `@events` was being checked in the `image` property definition in order to emit the `load` and `error` events once the image loading phase has ended. But this property `@events` is never created in the Layer class.

Renaming `@events` to `@_eventListeners` solves it.

It also solves issue #219 **PageComponent resets position of layer** by keeping the original position of the page before using `addPage` from a PageComponent