### PR TITLE
Fix issue #86: "Layer registration point vs originX/Y?"

### DIFF
--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -138,7 +138,6 @@ class exports.LayerStates extends BaseClass
 		keys = []
 
 		for stateName, state of @_states
-			continue if stateName is "default"
 			keys = _.union(keys, _.keys(state))
 
 		keys

--- a/test/tests/LayerStatesTest.coffee
+++ b/test/tests/LayerStatesTest.coffee
@@ -121,4 +121,17 @@ describe "LayerStates", ->
 
 			layer.states.switch "stateA", {curve:"linear", time:0.1}
 
-			
+		it "should restore the default state when using non exportable properties", ->
+
+			layer = new Layer
+			layer.states.add
+				stateA: {midX:200}
+
+			layer.x.should.equal 0
+
+			layer.states.switchInstant "stateA"
+			layer.x.should.equal 200 - (layer.width // 2)
+
+			layer.states.switchInstant "default"
+			layer.x.should.equal 0
+


### PR DESCRIPTION
I've tracked issue #86 down. The problem is the properties of the "default" state are being ignored if the other states don't include "exportable" properties.

So from the issue example, "goRight" state has only one property, `midX`. But when going back to the "default" state, nothing happens. This is what is going on behind the scenes:

1. The "default" state only includes exportable properties (see [line 23 of LayerStates.coffee](https://github.com/koenbok/Framer/blob/master/framer/LayerStates.coffee#L23) and [line 95 of BaseClass.coffee](https://github.com/koenbok/Framer/blob/master/framer/BaseClass.coffee#L95))
2. Thus, state `default` does not include `midX` property because it's not exportable (see [line 244 of Layer.coffee](https://github.com/koenbok/Framer/blob/master/framer/Layer.coffee#L244))
3. When going back to `default` state, `midX` is not animated because of 1. and 2., and `x` is not included either because all the props from `default` are ignored (see [line 141 of LayerStates.coffee](https://github.com/koenbok/Framer/blob/master/framer/LayerStates.coffee#L141))

By removing line 141 of LayerStates, all the `default` properties are included in the animations, and thus the `default` state is restored completely. This doesn't affect other custom states animations, as only the properties from each state are iterated.