### PR TITLE
Adding tests for state next() function and reversing commit ecf3c54

### DIFF
--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -138,7 +138,6 @@ class exports.LayerStates extends BaseClass
 		keys = []
 
 		for stateName, state of @_states
-			continue if stateName is "default"
 			keys = _.union(keys, _.keys(state))
 
 		keys

--- a/test/tests/LayerStatesTest.coffee
+++ b/test/tests/LayerStatesTest.coffee
@@ -73,6 +73,36 @@ describe "LayerStates", ->
 
 	describe "Properties", ->
 
+		it "should bring back the 'default' state values when using 'next'", (done) ->
+
+			layer = new Layer
+			layer.states.add
+				stateA: {x:100, rotation: 90}
+				stateB: {x:200, rotation: 180}
+			layer.states.animationOptions =
+				curve: "linear"
+				time: 0.05
+			
+			layer.x.should.equal 0
+
+			ready = (animation, layer) ->
+				switch layer.states.current
+					when "stateA"
+						layer.x.should.equal 100
+						layer.rotation.should.equal 90
+						layer.states.next()
+					when "stateB"
+						layer.x.should.equal 200
+						layer.rotation.should.equal 180
+						layer.states.next()
+					when "default"
+						layer.x.should.equal 0
+						layer.rotation.should.equal 0
+						done()
+
+			layer.on "end", ready
+			layer.states.next()
+			
 		it "should set scroll property", ->
 
 			layer = new Layer


### PR DESCRIPTION
After trying to replicate the error pointed out on commit [ecf3c54](https://github.com/koenbok/Framer/commit/ecf3c54a895267f288d64b8217c60363fe2f24a5) and not being able to do so, I have added a test to cover the `next()` function of the `states` object. 

The test adds two states to a layer and iterates through them, changing some positioning and rotation values, and finally calls 'next()' one more time to go back to `default`. After every state transition it verifies that the values are correct.

The PR includes the reverse commit for [ecf3c54](https://github.com/koenbok/Framer/commit/ecf3c54a895267f288d64b8217c60363fe2f24a5) and the mentioned test to cover it.