### PR TITLE
Added support for setting originZ on a Layer

### DIFF
--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -118,7 +118,7 @@ class exports.Layer extends BaseClass
 	# Matrix properties
 	@define "x", layerProperty(@, "x", "webkitTransform", 0, _.isNumber)
 	@define "y", layerProperty(@, "y", "webkitTransform", 0, _.isNumber)
-	@define "z", layerProperty(@, "z", "webkitTransform", 0, _.isNumber)
+	@define "z", layerProperty(@, "z", "webkitTransform", 0, _.isNumber, {relatedCssProperties: ['webkitTransformOrigin']})
 
 	@define "scaleX", layerProperty(@, "scaleX", "webkitTransform", 1, _.isNumber)
 	@define "scaleY", layerProperty(@, "scaleY", "webkitTransform", 1, _.isNumber)
@@ -135,7 +135,7 @@ class exports.Layer extends BaseClass
 
 	@define "originX", layerProperty(@, "originX", "webkitTransformOrigin", 0.5, _.isNumber)
 	@define "originY", layerProperty(@, "originY", "webkitTransformOrigin", 0.5, _.isNumber)
-	@define "originZ", layerProperty(@, "originZ", "webkitTransformOrigin", 0.5, _.isNumber)
+	@define "originZ", layerProperty(@, "originZ", "webkitTransformOrigin", 0, _.isNumber, {relatedCssProperties: ['webkitTransform']})
 
 	@define "perspective", layerProperty(@, "perspective", "webkitPerspective", 0, _.isNumber)
 

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -133,7 +133,7 @@ class exports.Layer extends BaseClass
 
 	@define "originX", layerProperty(@, "originX", "webkitTransformOrigin", 0.5, _.isNumber)
 	@define "originY", layerProperty(@, "originY", "webkitTransformOrigin", 0.5, _.isNumber)
-	# @define "originZ", layerProperty(@, "originZ", "WebkitTransformOrigin", 0.5
+	@define "originZ", layerProperty(@, "originZ", "webkitTransformOrigin", 0.5, _.isNumber)
 
 	@define "perspective", layerProperty(@, "perspective", "webkitPerspective", 0, _.isNumber)
 
@@ -611,6 +611,8 @@ class exports.Layer extends BaseClass
 
 			# Set the superlayer
 			@_superLayer = layer
+			if @_superLayer?.perspective != 0
+				@_element.style["webkitTransformOrigin"] = LayerStyle["webkitTransformOrigin"](@)
 
 			# Place this layer on top of its siblings
 			@bringToFront()

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -33,6 +33,8 @@ layerProperty = (obj, name, cssProperty, fallback, validator, options={}, set) -
 
 			@_properties[name] = value
 			@_element.style[cssProperty] = LayerStyle[cssProperty](@)
+			for property in options.relatedCssProperties ? []
+				@_element.style[property] = LayerStyle[property](@)
 
 			set?(@, value)
 			@emit("change:#{name}", value)

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -614,7 +614,7 @@ class exports.Layer extends BaseClass
 			# Set the superlayer
 			@_superLayer = layer
 			if @_superLayer?.perspective != 0
-				@_element.style["webkitTransformOrigin"] = LayerStyle["webkitTransformOrigin"](@)
+				@_element.style["webkitTransformStyle"] = "preserve-3d"
 
 			# Place this layer on top of its siblings
 			@bringToFront()

--- a/framer/LayerStyle.coffee
+++ b/framer/LayerStyle.coffee
@@ -91,15 +91,15 @@ exports.LayerStyle =
 			return exports.LayerStyle.webkitTransformForce2d(layer)
 
 		"
-		translate3d(#{layer._properties.x}px,#{layer._properties.y}px,#{layer._properties.z}px) 
+		translate3d(#{layer._properties.x}px,#{layer._properties.y}px,#{layer._properties.z+layer._properties.originZ}px)
 		scale(#{layer._properties.scale})
 		scale3d(#{layer._properties.scaleX},#{layer._properties.scaleY},#{layer._properties.scaleZ})
-		skew(#{layer._properties.skew}deg,#{layer._properties.skew}deg) 
-		skewX(#{layer._properties.skewX}deg)  
-		skewY(#{layer._properties.skewY}deg) 
-		rotateX(#{layer._properties.rotationX}deg) 
-		rotateY(#{layer._properties.rotationY}deg) 
-		rotateZ(#{layer._properties.rotationZ}deg) 
+		skew(#{layer._properties.skew}deg,#{layer._properties.skew}deg)
+		skewX(#{layer._properties.skewX}deg)
+		skewY(#{layer._properties.skewY}deg)
+		rotateX(#{layer._properties.rotationX}deg)
+		rotateY(#{layer._properties.rotationY}deg)
+		rotateZ(#{layer._properties.rotationZ}deg)
 		"
 
 	webkitTransformForce2d: (layer) ->

--- a/framer/LayerStyle.coffee
+++ b/framer/LayerStyle.coffee
@@ -121,9 +121,7 @@ exports.LayerStyle =
 		return css.join(" ")
 
 	webkitTransformOrigin: (layer) ->
-		perspective = layer.superLayer?._properties.perspective ? 0
-		zOffset = (layer._properties.originZ*2 - 1) * perspective
-		"#{layer._properties.originX * 100}% #{layer._properties.originY * 100}% #{zOffset}px"
+		"#{layer._properties.originX * 100}% #{layer._properties.originY * 100}% #{layer._properties.originZ}px"
 
 	webkitPerspective: (layer) ->
 		"#{layer._properties.perspective}"

--- a/framer/LayerStyle.coffee
+++ b/framer/LayerStyle.coffee
@@ -121,10 +121,9 @@ exports.LayerStyle =
 		return css.join(" ")
 
 	webkitTransformOrigin: (layer) ->
-		"#{layer._properties.originX * 100}% #{layer._properties.originY * 100}%"
-
-		# Todo: Origin z is in pixels. I need to read up on this.
-		# "#{layer._properties.originX * 100}% #{layer._properties.originY * 100}% #{layer._properties.originZ * 100}%"
+		perspective = layer.superLayer?._properties.perspective ? 0
+		zOffset = (layer._properties.originZ*2 - 1) * perspective
+		"#{layer._properties.originX * 100}% #{layer._properties.originY * 100}% #{zOffset}px"
 
 	webkitPerspective: (layer) ->
 		"#{layer._properties.perspective}"

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -102,18 +102,21 @@ describe "Layer", ->
 			layer = new Layer
 
 			layer.style.webkitTransformOrigin.should.equal "50% 50% 0px"
+			layer.style.webkitTransform.should.equal "translate3d(0px, 0px, 0px) scale(1) scale3d(1, 1, 1) skew(0deg, 0deg) skewX(0deg) skewY(0deg) rotateX(0deg) rotateY(0deg) rotateZ(0deg)"
 
 			layer.originX = 0.1
 			layer.originY = 0.2
 			layer.originZ = 80
 
 			layer.style.webkitTransformOrigin.should.equal "10% 20% 80px"
+			layer.style.webkitTransform.should.equal "translate3d(0px, 0px, 80px) scale(1) scale3d(1, 1, 1) skew(0deg, 0deg) skewX(0deg) skewY(0deg) rotateX(0deg) rotateY(0deg) rotateZ(0deg)"
 
 			layer.originX = 0.5
 			layer.originY = 0.5
 			layer.originZ = -50
 
 			layer.style.webkitTransformOrigin.should.equal "50% 50% -50px"
+			layer.style.webkitTransform.should.equal "translate3d(0px, 0px, -50px) scale(1) scale3d(1, 1, 1) skew(0deg, 0deg) skewX(0deg) skewY(0deg) rotateX(0deg) rotateY(0deg) rotateZ(0deg)"
 
 
 		it "should set local image", ->

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -98,24 +98,31 @@ describe "Layer", ->
 			layer.style.webkitTransform.should.equal "translate3d(0px, 0px, 0px) scale(1) scale3d(100, 100, 100) skew(0deg, 0deg) skewX(0deg) skewY(0deg) rotateX(0deg) rotateY(0deg) rotateZ(0deg)"
 
 		it "should set origin", ->
-			
+			superLayer = new Layer
+				perspective: 100
+
 			layer = new Layer
+
+			layer.style.webkitTransformOrigin.should.equal "50% 50% 0px"
+
+			layer.superLayer = superLayer
 
 			layer.originX = 0.1
 			layer.originY = 0.2
 
-			if Utils.isChrome()
-				layer.style.webkitTransformOrigin.should.equal "10% 20% 0px"
-			else
-				layer.style.webkitTransformOrigin.should.equal "10% 20%"
+			layer.style.webkitTransformOrigin.should.equal "10% 20% 0px"
 
 			layer.originX = 0.5
 			layer.originY = 0.5
+			layer.originZ = 0
 
-			if Utils.isChrome()
-				layer.style.webkitTransformOrigin.should.equal "50% 50% 0px"
-			else
-				layer.style.webkitTransformOrigin.should.equal "50% 50%"
+			layer.style.webkitTransformOrigin.should.equal "50% 50% -100px"
+
+			layer = new Layer
+				originZ: 0.75
+				originY: 0
+				superLayer: superLayer
+			layer.style.webkitTransformOrigin.should.equal "50% 0% 50px"
 
 		it "should set local image", ->
 	

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -118,6 +118,12 @@ describe "Layer", ->
 			layer.style.webkitTransformOrigin.should.equal "50% 50% -50px"
 			layer.style.webkitTransform.should.equal "translate3d(0px, 0px, -50px) scale(1) scale3d(1, 1, 1) skew(0deg, 0deg) skewX(0deg) skewY(0deg) rotateX(0deg) rotateY(0deg) rotateZ(0deg)"
 
+			it "should set transform-style when superlayer has perspective", ->
+				superLayer = new Layer
+					perspective: 100
+				layer = new Layer
+					superLayer: superLayer
+				layer._element.style.webkitTransformStyle.should.equal "preserve-3d"
 
 		it "should set local image", ->
 	

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -98,31 +98,23 @@ describe "Layer", ->
 			layer.style.webkitTransform.should.equal "translate3d(0px, 0px, 0px) scale(1) scale3d(100, 100, 100) skew(0deg, 0deg) skewX(0deg) skewY(0deg) rotateX(0deg) rotateY(0deg) rotateZ(0deg)"
 
 		it "should set origin", ->
-			superLayer = new Layer
-				perspective: 100
 
 			layer = new Layer
 
 			layer.style.webkitTransformOrigin.should.equal "50% 50% 0px"
 
-			layer.superLayer = superLayer
-
 			layer.originX = 0.1
 			layer.originY = 0.2
+			layer.originZ = 80
 
-			layer.style.webkitTransformOrigin.should.equal "10% 20% 0px"
+			layer.style.webkitTransformOrigin.should.equal "10% 20% 80px"
 
 			layer.originX = 0.5
 			layer.originY = 0.5
-			layer.originZ = 0
+			layer.originZ = -50
 
-			layer.style.webkitTransformOrigin.should.equal "50% 50% -100px"
+			layer.style.webkitTransformOrigin.should.equal "50% 50% -50px"
 
-			layer = new Layer
-				originZ: 0.75
-				originY: 0
-				superLayer: superLayer
-			layer.style.webkitTransformOrigin.should.equal "50% 0% 50px"
 
 		it "should set local image", ->
 	


### PR DESCRIPTION
This adds support for setting originZ on a Layer. Normally originZ would defined as a [length](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin), because an element has no z-dimension, so it doesn't make sense to define it relatively. 

However, these pixels are defined the same way as perspective (which is the ['distance between the z=0 plane and the user'](https://developer.mozilla.org/en-US/docs/Web/CSS/perspective), so if a Layer has a superLayer that has a perspective, we can use that as a reference. This way originZ can be defined relatively, just as originX and originY.

In this pull request changing a superLayer recalculates the origin, but changing the perspective of the superLayer doesn't. As the perspective value isn't usually something you want to be varying (as opposed to [perspective-origin](https://developer.mozilla.org/en-US/docs/Web/CSS/perspective-origin)), this doesn't seem a big problem to me.

Example prototype using this branch is here: http://share.framerjs.com/k44wfwqgs73z/