### PR TITLE
Change the domReady function to use interactive state

### DIFF
--- a/framer/Utils.coffee
+++ b/framer/Utils.coffee
@@ -406,24 +406,25 @@ Utils.parseFunction = (str) ->
 ######################################################
 # DOM FUNCTIONS
 
+__domCompleteState = "interactive"
 __domComplete = []
 __domReady = false
 
 if document?
-	document.onreadystatechange = (event) =>
-		if document.readyState is "complete"
+	document.onreadystatechange = (event) ->
+		if document.readyState is __domCompleteState
 			__domReady = true
 			while __domComplete.length
 				f = __domComplete.shift()()
 
 Utils.domComplete = (f) ->
-	if document.readyState is "complete"
+	if __domReady
 		f()
 	else
 		__domComplete.push(f)
 
 Utils.domCompleteCancel = (f) ->
-	__domComplete = _.without __domComplete, f
+	__domComplete = _.without(__domComplete, f)
 
 Utils.domValidEvent = (element, eventName) ->
 	return if not eventName


### PR DESCRIPTION
We can use `interactive` instead of `complete`, because the dom is ready to manipulate at interactive. Complete is still waiting for external resources, but also has a weird state where even if they take too long, it still decides to be ready.