### PR TITLE
Change hierarchy API: superLayer/subLayers → parent/children

### DIFF
--- a/framer/BackgroundLayer.coffee
+++ b/framer/BackgroundLayer.coffee
@@ -17,7 +17,7 @@ class exports.BackgroundLayer extends Layer
 		@_context.domEventManager.wrap(window).addEventListener("resize", @layout)
 	
 	layout: =>
-		if @superLayer
-			@frame = @superLayer.frame
+		if @parent
+			@frame = @parent.frame
 		else
 			@frame = @_context.frame

--- a/framer/Compat.coffee
+++ b/framer/Compat.coffee
@@ -17,16 +17,16 @@ class CompatLayer extends Layer
 	constructor: (options={}) ->
 
 		if options.hasOwnProperty "superView"
-			options.superLayer = options.superView
+			options.parent = options.superView
 
 		super options
 
-	@define "superView", compatProperty "superLayer", "superView"
-	@define "subViews", compatProperty "subLayers", "subViews"
+	@define "superView", compatProperty "parent", "superView"
+	@define "subViews", compatProperty "children", "subViews"
 	@define "siblingViews", compatProperty "siblingLayers", "siblingViews"
 
-	addSubView = (layer) -> @addSubLayer layer
-	removeSubView = (layer) -> @removeSubLayer layer
+	addSubView = (layer) -> @addChild layer
+	removeSubView = (layer) -> @removeChild layer
 
 class CompatView extends CompatLayer
 

--- a/framer/Components/DeviceComponent.coffee
+++ b/framer/Components/DeviceComponent.coffee
@@ -80,11 +80,11 @@ class exports.DeviceComponent extends BaseClass
 		@background.backgroundColor = "transparent"
 		@background.classList.add("DeviceBackground")
 
-		# @phone = new Layer superLayer:@background
+		# @phone = new Layer parent:@background
 		@phone = new Layer
-		@screen   = new Layer superLayer:@phone
-		@viewport = new Layer superLayer:@screen
-		@content  = new Layer superLayer:@viewport
+		@screen   = new Layer parent:@phone
+		@viewport = new Layer parent:@screen
+		@content  = new Layer parent:@viewport
 
 		@phone.backgroundColor = "transparent"
 		@phone.classList.add("DevicePhone")
@@ -101,7 +101,7 @@ class exports.DeviceComponent extends BaseClass
 		@content.originX = 0
 		@content.originY = 0
 
-		@keyboardLayer = new Layer superLayer:@viewport
+		@keyboardLayer = new Layer parent:@viewport
 		@keyboardLayer.on "click", => @toggleKeyboard()
 		@keyboardLayer.classList.add("DeviceKeyboard")
 		@keyboardLayer.backgroundColor = "transparent"

--- a/framer/Components/PageComponent.coffee
+++ b/framer/Components/PageComponent.coffee
@@ -34,7 +34,7 @@ class exports.PageComponent extends ScrollComponent
 		@on(Events.ScrollEnd, @_scrollEnd)
 
 		@content.on("change:frame", _.debounce(@_scrollMove, 16))
-		@content.on("change:subLayers", @_resetHistory)
+		@content.on("change:children", @_resetHistory)
 
 		@_resetHistory()
 
@@ -52,10 +52,10 @@ class exports.PageComponent extends ScrollComponent
 		if !withoutCurrentPage
 			point = {x:@scrollX + (@originX * @width), y:@scrollY + (@originY * @height)}
 
-		layers = @content.subLayersAbove(point, @originX, @originY) if direction in ["up", "top", "north"]
-		layers = @content.subLayersBelow(point, @originX, @originY) if direction in ["down", "bottom", "south"]
-		layers = @content.subLayersLeft(point, @originX, @originY) if direction in ["left", "west"]
-		layers = @content.subLayersRight(point, @originX, @originY) if direction in ["right", "east"]
+		layers = @content.childrenAbove(point, @originX, @originY) if direction in ["up", "top", "north"]
+		layers = @content.childrenBelow(point, @originX, @originY) if direction in ["down", "bottom", "south"]
+		layers = @content.childrenLeft(point, @originX, @originY) if direction in ["left", "west"]
+		layers = @content.childrenRight(point, @originX, @originY) if direction in ["right", "east"]
 
 		# See if there is one close by that we should go to
 		if withoutCurrentPage
@@ -99,18 +99,18 @@ class exports.PageComponent extends ScrollComponent
 			throw new Error("#{direction} should be in #{directions}")
 
 		# For allowing pages added with 'addPage' to behave consistently with pages added 
-		# to the PageComponent using 'superLayer', keep the original page point
+		# to the PageComponent using 'parent', keep the original page point
 		# so one of the two coordinates is left untouched after the page is added
 		point = page.point
 
-		if @content.subLayers.length
+		if @content.children.length
 			point.x = Utils.frameGetMaxX(@content.contentFrame()) if direction in ["right", "east"]
 			point.y = Utils.frameGetMaxY(@content.contentFrame()) if direction in ["down", "bottom", "south"]
 
 		page.point = point
 		
-		if page.superLayer isnt @content
-			page.superLayer = @content
+		if page.parent isnt @content
+			page.parent = @content
 		else
 			@updateContent()
 
@@ -124,10 +124,10 @@ class exports.PageComponent extends ScrollComponent
 		@content.on(Events.AnimationStop, @_onAminationEnd)
 
 	horizontalPageIndex: (page) ->
-		(_.sortBy(@content.subLayers, (l) -> l.x)).indexOf(page)
+		(_.sortBy(@content.children, (l) -> l.x)).indexOf(page)
 
 	verticalPageIndex: (page) ->
-		(_.sortBy(@content.subLayers, (l) -> l.y)).indexOf(page)
+		(_.sortBy(@content.children, (l) -> l.y)).indexOf(page)
 
 	_scrollStart: =>
 		@_currentPage = @currentPage

--- a/framer/Components/ScrollComponent.coffee
+++ b/framer/Components/ScrollComponent.coffee
@@ -114,12 +114,12 @@ class exports.ScrollComponent extends Layer
 		@_content.destroy() if @content
 
 		@_content = layer
-		@_content.superLayer = @
+		@_content.parent = @
 		@_content.name = "content"
 		@_content.clip = false
 		@_content.draggable.enabled = true
 		@_content.draggable.momentum = true
-		@_content.on("change:subLayers", @updateContent)
+		@_content.on("change:children", @updateContent)
 
 		# Update the content view size on resizing the ScrollComponent
 		@on("change:width", @updateContent)
@@ -158,10 +158,10 @@ class exports.ScrollComponent extends Layer
 
 		@content.draggable.constraints = constraintsFrame
 
-		# Change the default background color if we added subLayers. We keep the default 
+		# Change the default background color if we added children. We keep the default 
 		# color around until you set a content layer so you can see the ScrollComponent 
 		# on your screen after creation.
-		if @content.subLayers.length
+		if @content.children.length
 			if @content.backgroundColor?.isEqual(Framer.Defaults.Layer.backgroundColor)
 				@content.backgroundColor = null
 
@@ -267,10 +267,10 @@ class exports.ScrollComponent extends Layer
 
 	scrollToLayer: (contentLayer, originX=0, originY=0, animate=true, animationOptions={curve:"spring(500,50,0)"}) ->
 
-		if contentLayer and contentLayer.superLayer isnt @content
+		if contentLayer and contentLayer.parent isnt @content
 			throw Error("This layer is not in the scroll component content")
 
-		if not contentLayer or @content.subLayers.length == 0
+		if not contentLayer or @content.children.length == 0
 			scrollPoint = {x:0, y:0}
 		else
 			scrollPoint = @_scrollPointForLayer(contentLayer, originX, originY)
@@ -301,7 +301,7 @@ class exports.ScrollComponent extends Layer
 		return Utils.framePointForOrigin(layer, originX, originY)
 
 	_contentLayersSortedByDistanceForScrollPoint: (scrollPoint, originX=0, originY=0) ->
-		return Utils.frameSortByAbsoluteDistance(scrollPoint, @content.subLayers, originX, originY)
+		return Utils.frameSortByAbsoluteDistance(scrollPoint, @content.children, originX, originY)
 
 	_pointInConstraints: (point) ->
 
@@ -376,7 +376,7 @@ class exports.ScrollComponent extends Layer
 
 	copy: ->
 		copy = super
-		contentLayer = _.first(_.without(copy.subLayers, copy.content))
+		contentLayer = _.first(_.without(copy.children, copy.content))
 		copy.setContentLayer(contentLayer)
 		copy.props = @props
 		return copy
@@ -404,18 +404,18 @@ wrapComponent = (instance, layer, options = {correct:true}) ->
 	# correct that here.
 
 	if options.correct is true
-		if layer.subLayers.length is 0
+		if layer.children.length is 0
 			wrapper = new Layer
 			wrapper.name = "ScrollComponent"
 			wrapper.frame = layer.frame
-			layer.superLayer = wrapper
+			layer.parent = wrapper
 			layer.x = layer.y = 0
 			layer = wrapper
 
 			# console.info "Corrected the scroll component without sub layers"
 	
 	scroll.frame = layer.frame
-	scroll.superLayer = layer.superLayer
+	scroll.parent = layer.parent
 	scroll.index = layer.index
 	
 	# Copy over the name, if we don't have it try to use the variable

--- a/framer/Components/SliderComponent.coffee
+++ b/framer/Components/SliderComponent.coffee
@@ -57,7 +57,7 @@ class exports.SliderComponent extends Layer
 		super options
 
 		@knobSize = options.knobSize or 30
-		@knob.superLayer = @fill.superLayer = @knobOverlay.superLayer = @sliderOverlay.superLayer = @
+		@knob.parent = @fill.parent = @knobOverlay.parent = @sliderOverlay.parent = @
 
 		# Set fill initially
 		if @width > @height

--- a/framer/Importer.coffee
+++ b/framer/Importer.coffee
@@ -69,8 +69,8 @@ class exports.Importer
 		# Pass three, insert the layers into the dom
 		# (they were not inserted yet because of the shadow keyword)
 		for layer in @_createdLayers
-			if not layer.superLayer
-				layer.superLayer = null
+			if not layer.parent
+				layer.parent = null
 
 		return @_createdLayersByName
 
@@ -87,7 +87,7 @@ class exports.Importer
 
 		return Framer.Utils.domLoadJSONSync @paths.layerInfo
 
-	_createLayer: (info, superLayer) ->
+	_createLayer: (info, parent) ->
 
 		# Resize the layer frames
 		info.layerFrame = resizeFrame(@scale, info.layerFrame) if info.layerFrame
@@ -125,10 +125,10 @@ class exports.Importer
 
 		# Figure out what the super layer should be. If this layer has a contentLayer
 		# (like a scroll view) we attach it to that instead.
-		if superLayer?.contentLayer
-			layerInfo.superLayer = superLayer.contentLayer
-		else if superLayer
-			layerInfo.superLayer = superLayer
+		if parent?.contentLayer
+			layerInfo.parent = parent.contentLayer
+		else if parent
+			layerInfo.parent = parent
 
 		# Layer names cannot start with a number
 		if startsWithNumber(layerInfo.name)
@@ -149,7 +149,7 @@ class exports.Importer
 		if layerInfo.name.toLowerCase().indexOf("draggable") != -1
 			layer.draggable.enabled = true
 
-		# A layer without an image, mask or sublayers should be zero
+		# A layer without an image, mask or children should be zero
 		if not layer.image and not info.children.length and not info.maskFrame
 			layer.frame = Utils.frameZero()
 
@@ -198,13 +198,13 @@ class exports.Importer
 
 		traverse = (layer) ->
 
-			if layer.superLayer
-				layer.frame = Utils.convertPoint(layer.frame, null, layer.superLayer)
+			if layer.parent
+				layer.frame = Utils.convertPoint(layer.frame, null, layer.parent)
 
-			for subLayer in layer.subLayers
-				traverse(subLayer)
+			for Child in layer.children
+				traverse(Child)
 
-		if not layer.superLayer
+		if not layer.parent
 			traverse(layer)
 
 exports.Importer.load = (path, scale) ->

--- a/framer/Importer.coffee
+++ b/framer/Importer.coffee
@@ -201,8 +201,8 @@ class exports.Importer
 			if layer.parent
 				layer.frame = Utils.convertPoint(layer.frame, null, layer.parent)
 
-			for Child in layer.children
-				traverse(Child)
+			for child in layer.children
+				traverse(child)
 
 		if not layer.parent
 			traverse(layer)

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -61,7 +61,7 @@ class exports.Layer extends BaseClass
 		# Set needed private variables
 		@_properties = {}
 		@_style = {}
-		@_subLayers = []
+		@_children = []
 
 		# Special power setting for 2d rendering path. Only enable this
 		# if you know what you are doing. See LayerStyle for more info.
@@ -87,11 +87,15 @@ class exports.Layer extends BaseClass
 
 		@_id = @_context.layerCounter
 
-		# Insert the layer into the dom or the superLayer element
-		if not options.superLayer
+		# Backwards compatibility for superLayer
+		if not options.parent and options.hasOwnProperty("superLayer")
+			options.parent = options.superLayer
+
+		# Insert the layer into the dom or the parent element
+		if not options.parent
 			@_insertElement() if not options.shadow
 		else
-			@superLayer = options.superLayer
+			@parent = options.parent
 
 		# If an index was set, we would like to use that one
 		if options.hasOwnProperty("index")
@@ -307,10 +311,10 @@ class exports.Layer extends BaseClass
 		get: ->
 			Utils.convertPoint(@frame, @, null, context=true)
 		set: (frame) ->
-			if not @superLayer
+			if not @parent
 				@frame = frame
 			else
-				@frame = Utils.convertPoint(frame, null, @superLayer, context=true)
+				@frame = Utils.convertPoint(frame, null, @parent, context=true)
 
 	@define "screenFrame",
 		importable: true
@@ -318,21 +322,21 @@ class exports.Layer extends BaseClass
 		get: ->
 			Utils.convertPoint(@frame, @, null, context=false)
 		set: (frame) ->
-			if not @superLayer
+			if not @parent
 				@frame = frame
 			else
-				@frame = Utils.convertPoint(frame, null, @superLayer, context=false)
+				@frame = Utils.convertPoint(frame, null, @parent, context=false)
 
 	contentFrame: ->
-		return {x:0, y:0, width:0, height:0} unless @subLayers.length
-		Utils.frameMerge(_.pluck(@subLayers, "frame"))
+		return {x:0, y:0, width:0, height:0} unless @children.length
+		Utils.frameMerge(_.pluck(@children, "frame"))
 
 	centerFrame: ->
-		# Get the centered frame for its superLayer
-		if @superLayer
+		# Get the centered frame for its parent
+		if @parent
 			frame = @frame
-			Utils.frameSetMidX(frame, parseInt(@superLayer.width  / 2.0))
-			Utils.frameSetMidY(frame, parseInt(@superLayer.height / 2.0))
+			Utils.frameSetMidX(frame, parseInt(@parent.width  / 2.0))
+			Utils.frameSetMidY(frame, parseInt(@parent.height / 2.0))
 			return frame
 		else
 			frame = @frame
@@ -341,15 +345,15 @@ class exports.Layer extends BaseClass
 			return frame
 
 	center: ->
-		@frame = @centerFrame() # Center  in superLayer
+		@frame = @centerFrame() # Center  in parent
 		@
 	
 	centerX: (offset=0) ->
-		@x = @centerFrame().x + offset # Center x in superLayer
+		@x = @centerFrame().x + offset # Center x in parent
 		@
 	
 	centerY: (offset=0) ->
-		@y = @centerFrame().y + offset # Center y in superLayer
+		@y = @centerFrame().y + offset # Center y in parent
 		@
 
 	pixelAlign: ->
@@ -363,37 +367,37 @@ class exports.Layer extends BaseClass
 	# TODO: Rotation/Skew
 
 	# screenOriginX = ->
-	# 	if @_superOrParentLayer()
-	# 		return @_superOrParentLayer().screenOriginX()
+	# 	if @_parentOrContext()
+	# 		return @_parentOrContext().screenOriginX()
 	# 	return @originX
 	
 	# screenOriginY = ->
-	# 	if @_superOrParentLayer()
-	# 		return @_superOrParentLayer().screenOriginY()
+	# 	if @_parentOrContext()
+	# 		return @_parentOrContext().screenOriginY()
 	# 	return @originY
 
 	canvasScaleX: ->
 		scale = @scale * @scaleX
-		for superLayer in @superLayers(context=true)
-			scale = scale * superLayer.scale * superLayer.scaleX
+		for parent in @parents(context=true)
+			scale = scale * parent.scale * parent.scaleX
 		return scale
 
 	canvasScaleY: ->
 		scale = @scale * @scaleY
-		for superLayer in @superLayers(context=true)
-			scale = scale * superLayer.scale * superLayer.scaleY
+		for parent in @parents(context=true)
+			scale = scale * parent.scale * parent.scaleY
 		return scale
 
 	screenScaleX: ->
 		scale = @scale * @scaleX
-		for superLayer in @superLayers(context=false)
-			scale = scale * superLayer.scale * superLayer.scaleX
+		for parent in @parents(context=false)
+			scale = scale * parent.scale * parent.scaleX
 		return scale
 
 	screenScaleY: ->
 		scale = @scale * @scaleY
-		for superLayer in @superLayers(context=false)
-			scale = scale * superLayer.scale * superLayer.scaleY
+		for parent in @parents(context=false)
+			scale = scale * parent.scale * parent.scaleY
 		return scale
 
 
@@ -407,14 +411,14 @@ class exports.Layer extends BaseClass
 			width:  @width  * @screenScaleX()
 			height: @height * @screenScaleY()
 		
-		layers = @superLayers(context=true)
+		layers = @parents(context=true)
 		layers.push(@)
 		layers.reverse()
 		
-		for superLayer in layers
-			factorX = if superLayer._superOrParentLayer() then superLayer._superOrParentLayer().screenScaleX() else 1
-			factorY = if superLayer._superOrParentLayer() then superLayer._superOrParentLayer().screenScaleY() else 1
-			layerScaledFrame = superLayer.scaledFrame()
+		for parent in layers
+			factorX = if parent._parentOrContext() then parent._parentOrContext().screenScaleX() else 1
+			factorY = if parent._parentOrContext() then parent._parentOrContext().screenScaleY() else 1
+			layerScaledFrame = parent.scaledFrame()
 			frame.x += layerScaledFrame.x * factorX
 			frame.y += layerScaledFrame.y * factorY
 
@@ -505,8 +509,8 @@ class exports.Layer extends BaseClass
 		
 		# Todo: check this
 
-		if @superLayer
-			@superLayer._subLayers = _.without @superLayer._subLayers, @
+		if @parent
+			@parent._children = _.without @parent._children, @
 
 		@_element.parentNode?.removeChild @_element
 		@removeAllListeners()
@@ -525,9 +529,9 @@ class exports.Layer extends BaseClass
 
 		layer = @copySingle()
 
-		for subLayer in @subLayers
-			copiedSublayer = subLayer.copy()
-			copiedSublayer.superLayer = layer
+		for Child in @children
+			copiedChild = Child.copy()
+			copiedChild.parent = layer
 
 		layer
 
@@ -599,113 +603,128 @@ class exports.Layer extends BaseClass
 	##############################################################
 	## HIERARCHY
 
-	@define "superLayer",
+	@define "parent",
 		enumerable: false
 		exportable: false
 		importable: true
 		get: ->
-			@_superLayer or null
+			@_parent or null
 		set: (layer) ->
 
-			return if layer is @_superLayer
+			return if layer is @_parent
 
 			# Check the type
 			if not layer instanceof Layer
-				throw Error "Layer.superLayer needs to be a Layer object"
+				throw Error "Layer.parent needs to be a Layer object"
 
 			# Cancel previous pending insertions
 			Utils.domCompleteCancel @__insertElement
 
-			# Remove from previous superlayer sublayers
-			if @_superLayer
-				@_superLayer._subLayers = _.without @_superLayer._subLayers, @
-				@_superLayer._element.removeChild @_element
-				@_superLayer.emit "change:subLayers", {added:[], removed:[@]}
+			# Remove from previous parent children
+			if @_parent
+				@_parent._children = _.without @_parent._children, @
+				@_parent._element.removeChild @_element
+				@_parent.emit "change:children", {added:[], removed:[@]}
 
-			# Either insert the element to the new superlayer element or into dom
+			# Either insert the element to the new parent element or into dom
 			if layer
 				layer._element.appendChild @_element
-				layer._subLayers.push @
-				layer.emit "change:subLayers", {added:[@], removed:[]}
+				layer._children.push @
+				layer.emit "change:children", {added:[@], removed:[]}
 			else
 				@_insertElement()
 
-			# Set the superlayer
-			@_superLayer = layer
+			# Set the parent
+			@_parent = layer
 
 			# Place this layer on top of its siblings
 			@bringToFront()
 
+			@emit "change:parent"
 			@emit "change:superLayer"
 
-	# Todo: should we have a recursive subLayers function?
-	# Let's make it when we need it.
-
-	@define "subLayers",
+	@define "children",
 		enumerable: false
 		exportable: false
 		importable: false
-		get: -> _.clone @_subLayers
+		get: -> _.clone @_children
 
-	@define "siblingLayers",
+	@define "siblings",
 		enumerable: false
 		exportable: false
 		importable: false
 		get: ->
 
-			# If there is no superLayer we need to walk through the root
-			if @superLayer is null
+			# If there is no parent we need to walk through the root
+			if @parent is null
 				return _.filter @_context.getLayers(), (layer) =>
-					layer isnt @ and layer.superLayer is null
+					layer isnt @ and layer.parent is null
 
-			return _.without @superLayer.subLayers, @
+			return _.without @parent.children, @
 
-	addSubLayer: (layer) ->
-		layer.superLayer = @
+	addChild: (layer) ->
+		layer.parent = @
 
-	removeSubLayer: (layer) ->
+	removeChild: (layer) ->
 
-		if layer not in @subLayers
+		if layer not in @children
 			return
 
-		layer.superLayer = null
+		layer.parent = null
 
-	subLayersByName: (name) ->
-		_.filter @subLayers, (layer) -> layer.name == name
+	childrenByName: (name) ->
+		_.filter @children, (layer) -> layer.name == name
 
-	siblingLayersByName: (name) ->
+	siblingsByName: (name) ->
 		_.filter @siblingLayers, (layer) -> layer.name == name
 
-	superLayers: (context=false) ->
+	parents: (context=false) ->
 
-		superLayers = []
+		parents = []
 		currentLayer = @
 
 		if context is false
-			while currentLayer.superLayer
-				superLayers.push(currentLayer.superLayer)
-				currentLayer = currentLayer.superLayer
+			while currentLayer.parent
+				parents.push(currentLayer.parent)
+				currentLayer = currentLayer.parent
 		else
-			while currentLayer._superOrParentLayer()
-				superLayers.push(currentLayer._superOrParentLayer())
-				currentLayer = currentLayer._superOrParentLayer()
+			while currentLayer._parentOrContext()
+				parents.push(currentLayer._parentOrContext())
+				currentLayer = currentLayer._parentOrContext()
 
-		return superLayers
+		return parents
 
-	_superOrParentLayer: ->
-		if @superLayer
-			return @superLayer
+	childrenAbove: (point, originX=0, originY=0) -> _.filter @children, (layer) -> 
+		Utils.framePointForOrigin(layer.frame, originX, originY).y < point.y
+	childrenBelow: (point, originX=0, originY=0) -> _.filter @children, (layer) -> 
+		Utils.framePointForOrigin(layer.frame, originX, originY).y > point.y
+	childrenLeft: (point, originX=0, originY=0) -> _.filter @children, (layer) -> 
+		Utils.framePointForOrigin(layer.frame, originX, originY).x < point.x
+	childrenRight: (point, originX=0, originY=0) -> _.filter @children, (layer) -> 
+		Utils.framePointForOrigin(layer.frame, originX, originY).x > point.x
+
+	_parentOrContext: ->
+		if @parent
+			return @parent
 		if @_context._parent
 			return @_context._parent
 
-	subLayersAbove: (point, originX=0, originY=0) -> _.filter @subLayers, (layer) -> 
-		Utils.framePointForOrigin(layer.frame, originX, originY).y < point.y
-	subLayersBelow: (point, originX=0, originY=0) -> _.filter @subLayers, (layer) -> 
-		Utils.framePointForOrigin(layer.frame, originX, originY).y > point.y
-	subLayersLeft: (point, originX=0, originY=0) -> _.filter @subLayers, (layer) -> 
-		Utils.framePointForOrigin(layer.frame, originX, originY).x < point.x
-	subLayersRight: (point, originX=0, originY=0) -> _.filter @subLayers, (layer) -> 
-		Utils.framePointForOrigin(layer.frame, originX, originY).x > point.x
+	##############################################################
+	# Backwards superLayer and children compatibility
+
+	@define("superLayer", @proxyProperty("parent", importable:false))
+	@define("superLayers", @proxyProperty("parents", importable:false))
+	@define("subLayers", @proxyProperty("children", importable:false))
+	@define("siblingLayers", @proxyProperty("siblings", importable:false))
+
+	addSubLayer: (layer) -> @addChild(layer)
+	removeSubLayer: (layer) -> @removeChild(layer)
+	subLayersByName: (name) -> @childrenByName(name)
+	siblingLayersByName: (name) -> @siblingsByName(name)
+	subLayersAbove: (point, originX=0, originY=0) -> @childrenAbove(point, originX, originY)
+	subLayersBelow: (point, originX=0, originY=0) -> @childrenBelow(point, originX, originY)
+	subLayersLeft: (point, originX=0, originY=0) -> @childrenLeft(point, originX, originY)
+	subLayersRight: (point, originX=0, originY=0) -> @childrenRight(point, originX, originY)
 
 	##############################################################
 	## ANIMATION
@@ -881,7 +900,7 @@ class exports.Layer extends BaseClass
 			@_domEventManager.removeAllListeners(eventName)
 
 	_parentDraggableLayer: ->
-		for layer in @superLayers().concat(@)
+		for layer in @parents().concat(@)
 			return layer if layer._draggable?.enabled
 		return null 
 

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -725,6 +725,7 @@ class exports.Layer extends BaseClass
 	subLayersBelow: (point, originX=0, originY=0) -> @childrenBelow(point, originX, originY)
 	subLayersLeft: (point, originX=0, originY=0) -> @childrenLeft(point, originX, originY)
 	subLayersRight: (point, originX=0, originY=0) -> @childrenRight(point, originX, originY)
+	_superOrParentLayer: -> @_parentOrContext()
 
 	##############################################################
 	## ANIMATION

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -529,8 +529,8 @@ class exports.Layer extends BaseClass
 
 		layer = @copySingle()
 
-		for Child in @children
-			copiedChild = Child.copy()
+		for child in @children
+			copiedChild = child.copy()
 			copiedChild.parent = layer
 
 		layer

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -664,6 +664,21 @@ class exports.Layer extends BaseClass
 
 			return _.without @parent.children, @
 
+	@define "descendants",
+		enumerable: false
+		exportable: false
+		importable: false
+		get: ->
+			result = []
+			
+			f = (layer) ->
+				result.push(layer)
+				layer.children.map(f)
+			
+			@children.map(f)
+				
+			return result
+
 	addChild: (layer) ->
 		layer.parent = @
 

--- a/framer/LayerAnchor.coffee
+++ b/framer/LayerAnchor.coffee
@@ -18,7 +18,7 @@ calculateFrame = (layer, rules) ->
 		rules["centerX"] = val("center")
 		rules["centerY"] = val("center")
 	
-	parentSize = layer.superLayer
+	parentSize = layer.parent
 	parentSize ?= Screen
 	
 	frame = layer.frame
@@ -59,7 +59,7 @@ class LayerAnchor extends EventEmitter
 
 	updateRules: (rules) ->
 		@rules = @_parseRules(rules)
-		@layer.on("change:superLayer", @_setupListener)
+		@layer.on("change:parent", @_setupListener)
 		@_setNeedsUpdate()
 		# @_needsUpdate = false
 		@_removeListeners()
@@ -69,8 +69,8 @@ class LayerAnchor extends EventEmitter
 		
 		@_removeListeners()
 		
-		if @layer.superLayer
-			@_addListener(@layer.superLayer, "change:frame", @_setNeedsUpdate)
+		if @layer.parent
+			@_addListener(@layer.parent, "change:frame", @_setNeedsUpdate)
 		else
 			@_addListener(Canvas, "resize", @_setNeedsUpdate)
 			

--- a/framer/Utils.coffee
+++ b/framer/Utils.coffee
@@ -719,16 +719,16 @@ Utils.convertPoint = (input, layerA, layerB, context=false) ->
 
 	point = _.defaults(input, {x:0, y:0})
 
-	superLayersA = layerA?.superLayers(context) or []
-	superLayersB = layerB?.superLayers(context) or []
+	parentsA = layerA?.parents(context) or []
+	parentsB = layerB?.parents(context) or []
 
-	superLayersB.push(layerB) if layerB
+	parentsB.push(layerB) if layerB
 
-	for layer in superLayersA
+	for layer in parentsA
 		point.x += layer.x #- layer.scrollFrame.x
 		point.y += layer.y #- layer.scrollFrame.y
 
-	for layer in superLayersB
+	for layer in parentsB
 		point.x -= layer.x #+ layer.scrollFrame.x
 		point.y -= layer.y #+ layer.scrollFrame.y
 

--- a/framer/Utils.coffee
+++ b/framer/Utils.coffee
@@ -719,8 +719,8 @@ Utils.convertPoint = (input, layerA, layerB, context=false) ->
 
 	point = _.defaults(input, {x:0, y:0})
 
-	parentsA = layerA?.parents(context) or []
-	parentsB = layerB?.parents(context) or []
+	parentsA = layerA?.ancestors(context) or []
+	parentsB = layerB?.ancestors(context) or []
 
 	parentsB.push(layerB) if layerB
 

--- a/test/tests/ImporterTest.coffee
+++ b/test/tests/ImporterTest.coffee
@@ -15,7 +15,7 @@ describe "ExternalDocument", ->
 			dataB[layerName] =
 				frame: layer.frame
 				superLayerName: layer.superLayer?.layerName
-				subLayerNames: layer.subLayers.map (l) -> l.name
+				subLayerNames: layer.children.map (l) -> l.name
 				# clip: layer.clip
 
 		jsonA = JSON.stringify dataA, null, "\t"

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -500,7 +500,7 @@ describe "Layer", ->
 			f = -> layer = new Layer superLayer:1
 			f.should.throw()
 
-		it "should add Child", ->
+		it "should add child", ->
 			
 			layerA = new Layer
 			layerB = new Layer superLayer:layerA
@@ -508,7 +508,7 @@ describe "Layer", ->
 			assert.equal layerB._element.parentNode, layerA._element
 			assert.equal layerB.superLayer, layerA
 
-		it "should remove Child", ->
+		it "should remove child", ->
 
 			layerA = new Layer
 			layerB = new Layer superLayer:layerA

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -642,8 +642,8 @@ describe "Layer", ->
 			layerC = new Layer name:"C", superLayer:layerA
 			layerD = new Layer name:"C", superLayer:layerA
 
-			layerA.childrenByName("B").should.eql [layerB]
-			layerA.childrenByName("C").should.eql [layerC, layerD]
+			layerA.childrenWithName("B").should.eql [layerB]
+			layerA.childrenWithName("C").should.eql [layerC, layerD]
 
 		it "should get a siblinglayer by name", ->
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -559,6 +559,21 @@ describe "Layer", ->
 
 			assert.deepEqual layerC.superLayers(), [layerB, layerA]
 
+		it "should list descendants deeply", ->
+
+			layerA = new Layer
+			layerB = new Layer superLayer:layerA
+			layerC = new Layer superLayer:layerB
+
+			layerA.descendants.should.eql [layerB, layerC]
+
+		it "should list descendants", ->
+
+			layerA = new Layer
+			layerB = new Layer superLayer:layerA
+			layerC = new Layer superLayer:layerA
+
+			layerA.descendants.should.eql [layerB, layerC]
 
 			
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -500,7 +500,7 @@ describe "Layer", ->
 			f = -> layer = new Layer superLayer:1
 			f.should.throw()
 
-		it "should add sublayer", ->
+		it "should add Child", ->
 			
 			layerA = new Layer
 			layerB = new Layer superLayer:layerA
@@ -508,7 +508,7 @@ describe "Layer", ->
 			assert.equal layerB._element.parentNode, layerA._element
 			assert.equal layerB.superLayer, layerA
 
-		it "should remove sublayer", ->
+		it "should remove Child", ->
 
 			layerA = new Layer
 			layerB = new Layer superLayer:layerA
@@ -518,20 +518,20 @@ describe "Layer", ->
 			assert.equal layerB._element.parentNode.id, "FramerContextRoot-Default"
 			assert.equal layerB.superLayer, null
 
-		it "should list sublayers", ->
+		it "should list children", ->
 
 			layerA = new Layer
 			layerB = new Layer superLayer:layerA
 			layerC = new Layer superLayer:layerA
 
-			assert.deepEqual layerA.subLayers, [layerB, layerC]
+			assert.deepEqual layerA.children, [layerB, layerC]
 
 			layerB.superLayer = null
-			assert.equal layerA.subLayers.length, 1
-			assert.deepEqual layerA.subLayers, [layerC]
+			assert.equal layerA.children.length, 1
+			assert.deepEqual layerA.children, [layerC]
 
 			layerC.superLayer = null
-			assert.deepEqual layerA.subLayers, []
+			assert.deepEqual layerA.children, []
 
 		it "should list sibling root layers", ->
 
@@ -635,15 +635,15 @@ describe "Layer", ->
 			assert.equal layerC.index, 1
 			assert.equal layerD.index, 4
 
-		it "should get a sublayers by name", ->
+		it "should get a children by name", ->
 
 			layerA = new Layer
 			layerB = new Layer name:"B", superLayer:layerA
 			layerC = new Layer name:"C", superLayer:layerA
 			layerD = new Layer name:"C", superLayer:layerA
 
-			layerA.subLayersByName("B").should.eql [layerB]
-			layerA.subLayersByName("C").should.eql [layerC, layerD]
+			layerA.childrenByName("B").should.eql [layerB]
+			layerA.childrenByName("C").should.eql [layerC, layerD]
 
 		it "should get a siblinglayer by name", ->
 
@@ -841,13 +841,13 @@ describe "Layer", ->
 			layer._elementHTML.innerHTML.should.equal "Hello"
 			layer.ignoreEvents.should.equal true
 
-		it "should not effect subLayers", ->
+		it "should not effect children", ->
 
 			layer = new Layer
 			layer.html = "Hello"
-			subLayer = new Layer superLayer: layer
+			Child = new Layer superLayer: layer
 
-			subLayer._element.offsetTop.should.equal 0
+			Child._element.offsetTop.should.equal 0
 
 		it "should set interactive html and allow pointer events", ->
 

--- a/test/tests/ScrollComponentTest.coffee
+++ b/test/tests/ScrollComponentTest.coffee
@@ -16,7 +16,7 @@ describe "ScrollComponent", ->
 
 	describe "wrap", ->
 
-		it "should use the wrapped layer as content layer when there are sublayers", ->
+		it "should use the wrapped layer as content layer when there are children", ->
 
 			layerA = new Layer frame:Screen.frame
 			layerB = new Layer superLayer:layerA
@@ -24,12 +24,12 @@ describe "ScrollComponent", ->
 			scroll = ScrollComponent.wrap(layerA)
 			scroll.content.should.equal layerA
 
-		it "should use the wrapped layer as content if there are no sublayers", ->
+		it "should use the wrapped layer as content if there are no children", ->
 
 			layerA = new Layer frame:Screen.frame
 
 			scroll = ScrollComponent.wrap(layerA)
-			scroll.content.subLayers[0].should.equal layerA
+			scroll.content.children[0].should.equal layerA
 
 		it "should copy the name and image", ->
 
@@ -57,7 +57,7 @@ describe "ScrollComponent", ->
 			scroll.width.should.equal Screen.width
 			scroll.height.should.equal Screen.height
 
-		it "should correct the scroll frame with sublayers", ->
+		it "should correct the scroll frame with children", ->
 
 			frame = Screen.frame
 			frame.width += 100


### PR DESCRIPTION
We are going to change the superLayer/subLayers keywords to parent/children. The words look less intimidating and are more descriptive of what they do.

I often noticed that beginning programmers don't get the terminology of super/sub, whereas everyone understands parent/children right away.

Old methods will continue to work for a while so old tutorials and prototypes continue to work.

List of changed methods:

```coffee
.superLayer -> parent
.subLayers -> children
.siblingLayers -> siblings

superLayers: (context=false) -> ancestors: (context=false)
addSubLayer: (layer) -> @addChild(layer)
removeSubLayer: (layer) -> @removeChild(layer)
subLayersByName: (name) -> @childrenWithName(name)
siblingLayersByName: (name) -> @siblingsWithName(name)
subLayersAbove: (point, originX=0, originY=0) -> @childrenAbove(point, originX, originY)
subLayersBelow: (point, originX=0, originY=0) -> @childrenBelow(point, originX, originY)
subLayersLeft: (point, originX=0, originY=0) -> @childrenLeft(point, originX, originY)
subLayersRight: (point, originX=0, originY=0) -> @childrenRight(point, originX, originY)
_superOrParentLayer: -> @_parentOrContext()
```

List of new methods:

```
.descendants
```