### PR TITLE
Canvas backgroundColor and image 

### DIFF
--- a/framer/Canvas.coffee
+++ b/framer/Canvas.coffee
@@ -8,6 +8,18 @@ class CanvasClass extends BaseClass
 	@define "size", get: -> {width:@width, height:@height}
 	@define "frame", get: -> {x:0, y:0, width:@width, height:@height}
 
+	@define "backgroundColor",
+		importable: false
+		exportable: false
+		get: -> Framer.Device.background.backgroundColor
+		set: (value) -> Framer.Device.background.backgroundColor = value
+
+	@define "image",
+		importable: false
+		exportable: false
+		get: -> Framer.Device.background.image
+		set: (value) -> Framer.Device.background.image = value
+
 	addListener: (eventName, listener) =>
 		if eventName is "resize"
 			Events.wrap(window).addEventListener "resize", =>


### PR DESCRIPTION
#### New Canvas properties:

`Canvas.backgroundColor`
`Canvas.image`

#### Example

```coffee
Framer.Device.background.backgroundColor = "28AFFA"
Framer.Device.background.image = "images/bg.png"
```
vs
```coffee
Canvas.backgroundColor = "28AFFA"
Canvas.image = "images/bg.png"
```