### PR TITLE
Fix for mouseWheelEnabled at initialization

### DIFF
--- a/framer/Components/ScrollComponent.coffee
+++ b/framer/Components/ScrollComponent.coffee
@@ -86,7 +86,7 @@ class exports.ScrollComponent extends Layer
 		# Because we did not have a content layer before, we want to re-apply
 		# the options again so everything gets configures properly.
 		@_applyOptionsAndDefaults(options)
-		@_enableMouseWheelHandling()
+		@_enableMouseWheelHandling(options.mouseWheelEnabled)
 
 		if options.hasOwnProperty("wrap")
 			wrapComponent(@, options.wrap)


### PR DESCRIPTION
Regardless if you pass the option when you create the component it will always default to false. This should pass the option in when it's initialized so it works as expected.