### PR TITLE
Allow borderRadius to be set to an Array

### DIFF
--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -274,8 +274,11 @@ class exports.Layer extends BaseClass
 
 		set: (value) ->
 
-			if value and not _.isNumber(value)
-				console.warn "Layer.borderRadius should be a numeric property, not type #{typeof(value)}"
+			if value and not (_.isNumber(value) or _.isArray(value))
+				console.warn "Layer.borderRadius should be a numeric property or an array, not type #{typeof(value)}"
+
+			if value and _.isArray(value) and value.length > 4
+				 console.warn "Layer.borderRadius should not be set to more than 4 values"
 
 			@_properties["borderRadius"] = value
 			@_element.style["borderRadius"] = LayerStyle["borderRadius"](@)

--- a/framer/LayerStyle.coffee
+++ b/framer/LayerStyle.coffee
@@ -174,10 +174,14 @@ exports.LayerStyle =
 	borderRadius: (layer) ->
 
 		# Compatibility fix, remove later
-		if not _.isNumber(layer._properties.borderRadius)
-			return layer._properties.borderRadius
+		if _.isNumber(layer._properties.borderRadius)
+			return layer._properties.borderRadius + "px"
 
-		return layer._properties.borderRadius + "px"
+		if _.isArray(layer._properties.borderRadius) and _.compact(layer._properties.borderRadius.map(_.isNumber).length == layer._properties.borderRadius.length)
+			return _.take(layer._properties.borderRadius, 4).map((corner) -> corner + "px").join(" ")
+
+		# else
+		return layer._properties.borderRadius
 
 	border: (layer) ->
 		return "#{layer._properties.borderWidth}px solid #{layer._properties.borderColor}"


### PR DESCRIPTION
This allows the `borderRadius` of a `Layer` to be set to an array, to have different radiuses for different corners.

TODO:
- [ ] Add tests