### PR TITLE
Design @1x

### DIFF
--- a/framer/Components/DeviceComponent.coffee
+++ b/framer/Components/DeviceComponent.coffee
@@ -388,10 +388,7 @@ class exports.DeviceComponent extends BaseClass
 		@_contentScale = contentScale
 
 		if animate
-			@content.animate _.extend @animationOptions,
-				properties: {scale: @_contentScale}
-		else
-			@content.scale = @_contentScale
+			@content.animate @animationOptions
 
 		@_update()
 

--- a/framer/Components/DeviceComponent.coffee
+++ b/framer/Components/DeviceComponent.coffee
@@ -388,7 +388,10 @@ class exports.DeviceComponent extends BaseClass
 		@_contentScale = contentScale
 
 		if animate
-			@content.animate @animationOptions
+			@content.animate _.extend @animationOptions,
+				properties: {scale: @_contentScale}
+		else
+			@content.scale = @_contentScale
 			
 		@_setViewportScale()
 		@_update()

--- a/framer/Components/DeviceComponent.coffee
+++ b/framer/Components/DeviceComponent.coffee
@@ -39,6 +39,8 @@ Events.DeviceFullScreenDidChange
 # 	DeviceContentScaleDidChange: "change:contentScale"
 # 	DeviceFullScreenDidChange: ""
 
+viewportMetaElement = null
+
 class exports.DeviceComponent extends BaseClass
 
 	@define "context", get: -> @_context
@@ -113,16 +115,13 @@ class exports.DeviceComponent extends BaseClass
 		# Todo: pixel align at zoom level 1, 0.5
 
 		contentScaleFactor = @contentScale
-		contentScaleFactor = 1 if contentScaleFactor > 1
 
 		if @_shouldRenderFullScreen()
 			for layer in [@background, @hands, @phone, @viewport, @content, @screen]
 				layer.x = layer.y = 0
-				layer.width = window.innerWidth / contentScaleFactor
-				layer.height = window.innerHeight / contentScaleFactor
+				layer.width = window.innerWidth
+				layer.height = window.innerHeight
 				layer.scale = 1
-
-			@content.scale = contentScaleFactor
 
 		else
 			backgroundOverlap = 100
@@ -145,6 +144,7 @@ class exports.DeviceComponent extends BaseClass
 
 			@content.width  = width
 			@content.height = height
+			@content.scale = contentScaleFactor
 			@screen.center()
 
 			@setHand(@selectedHand) if @selectedHand && @_orientation == 0
@@ -389,10 +389,27 @@ class exports.DeviceComponent extends BaseClass
 
 		if animate
 			@content.animate @animationOptions
-
+			
+		@_setViewportScale()
 		@_update()
 
 		@emit("change:contentScale")
+
+	_setViewportScale: ->
+		scale = @contentScale / window.devicePixelRatio
+		viewport = """
+			width=device-width,
+			height=device-height,
+			initial-scale=#{scale},
+			maximum-scale=#{scale},
+			user-scalable=no"""
+		iOS = /iPad|iPhone|iPod/.test(navigator.platform)
+		if (iOS) then viewport += ", shrink-to-fit=no"
+
+		unless viewportMetaElement
+			viewportMetaElement = document.querySelector "meta[name='viewport']"
+
+		viewportMetaElement.content = viewport
 
 
 	###########################################################################


### PR DESCRIPTION
I'm back :)

@koenbok I simplified my approach from #228, but now need a little help from you to get this in an acceptable state to merge.
## Must-haves
- [ ] when importing from Sketch/Photoshop, honor `Framer.Device.contentScale` by drawing all imported layers at the appropriate size (divided by the scale factor)

I'm a bit confused with the existing behavior because if I import a design drawn at 1x using the new importer scaling feature, all my layer dimensions are scaled by that factor, yet the `layerFrame` and `image.frame` values in the generated JSON are relative (at 1x) values.
## Nice-to-haves
- [ ] trigger a refresh of the device context when changing orientation so that it is not necessary to reload the preview (this would be great to trigger on device as well if it is possible)
- [ ] make the viewport meta tag generator DRY (maybe create a build step for including a factored-out version of the function both in `index.html` and `DeviceComponent.coffee`)
- [ ] consider making a less explicit API that requires direct knowledge of device scale factors and make something more implicit like `DeviceComponent#relativeUnits` and then do the extra legwork to add the appropriate `contentScale` properties to the built-in device configurations
- [ ] test(s) for fullscreen and simulated device contexts
