### PR TITLE
Fixed align for layers without borderWidth

### DIFF
--- a/framer/Align.coffee
+++ b/framer/Align.coffee
@@ -1,8 +1,10 @@
 center = (layer, property, offset=0) ->
 	parent = Screen
 	parent = layer.parent if layer.parent
-	return (parent.width / 2) - (layer.width / 2) - parent.borderWidth + offset if property is "x"
-	return (parent.height / 2) - (layer.height / 2) - parent.borderWidth + offset if property is "y"
+	borderWidth = parent.borderWidth
+	borderWidth ?= 0
+	return (parent.width / 2) - (layer.width / 2) - borderWidth + offset if property is "x"
+	return (parent.height / 2) - (layer.height / 2) - borderWidth + offset if property is "y"
 	return 0
 
 left = (layer, property, offset=0) ->
@@ -15,7 +17,9 @@ right = (layer, property, offset=0) ->
 	throw Error "Align.right only works for x" unless property is "x"
 	parent = Screen
 	parent = layer.parent if layer.parent
-	return parent.width - (2 * parent.borderWidth) - layer.width + offset
+	borderWidth = parent.borderWidth
+	borderWidth ?= 0
+	return parent.width - (2 * borderWidth) - layer.width + offset
 
 top = (layer, property, offset=0) ->
 	throw Error "Align.top only works for y" unless property is "y"
@@ -27,7 +31,9 @@ bottom = (layer, property, offset=0) ->
 	throw Error "Align.bottom only works for y" unless property is "y"
 	parent = Screen
 	parent = layer.parent if layer.parent
-	return parent.height - (2 * parent.borderWidth) - layer.height + offset
+	borderWidth = parent.borderWidth
+	borderWidth ?= 0
+	return parent.height - (2 * borderWidth) - layer.height + offset
 
 wrapper = (f) ->
 	return (a, b) ->

--- a/test/tests/AlignTest.coffee
+++ b/test/tests/AlignTest.coffee
@@ -20,21 +20,43 @@ describe "Align", ->
 			child.x.should.equal 200
 			{child} = createAlignedLayers('y',Align.center)
 			child.y.should.equal 50
+		it "should work when the layer has no parent", ->
+			layer = new Layer
+				width: 100
+				height: 150
+				x: Align.center
+				y: Align.center
+			layer.x.should.equal 150
+			layer.y.should.equal 75
 		it "should take borderWidth into account", ->
 			{child} = createAlignedLayers('x',Align.center,{borderWidth:30})
 			child.x.should.equal 170
 			{child} = createAlignedLayers('y',Align.center,{borderWidth:30})
 			child.y.should.equal 20
 
+
 	describe "left", ->
 		it "should left align the layer", ->
 			{child} = createAlignedLayers('x',Align.left)
+			child.x.should.equal 0
+		it "should work when the layer has no parent", ->
+			layer = new Layer
+				width: 100
+				x: Align.left
+			layer.x.should.equal 0
+		it "should take borderWidth into account", ->
+			{child} = createAlignedLayers('x',Align.left,{borderWidth:30})
 			child.x.should.equal 0
 
 	describe "right", ->
 		it "should right align the layer", ->
 			{child} = createAlignedLayers('x',Align.right)
 			child.x.should.equal 400
+		it "should work when the layer has no parent", ->
+			layer = new Layer
+				width: 100
+				x: Align.right
+			layer.x.should.equal 300
 		it "should take borderWidth into account", ->
 			{child} = createAlignedLayers('x',Align.right,{borderWidth:30})
 			child.x.should.equal 340
@@ -43,6 +65,11 @@ describe "Align", ->
 		it "should top align the layer", ->
 			{child} = createAlignedLayers('y',Align.top)
 			child.y.should.equal 0
+		it "should work when the layer has no parent", ->
+			layer = new Layer
+				height: 100
+				y: Align.top
+			layer.y.should.equal 0
 		it "should take borderWidth into account", ->
 			{child} = createAlignedLayers('y',Align.top,{borderWidth:30})
 			child.y.should.equal 0
@@ -51,6 +78,11 @@ describe "Align", ->
 		it "should bottom align the layer", ->
 			{child} = createAlignedLayers('y',Align.bottom)
 			child.y.should.equal 100
+		it "should work when the layer has no parent", ->
+			layer = new Layer
+				height: 100
+				y: Align.bottom
+			layer.y.should.equal 200
 		it "should take borderWidth into account", ->
 			{child} = createAlignedLayers('y',Align.bottom,{borderWidth:30})
 			child.y.should.equal 40


### PR DESCRIPTION
Fixes problem where layers aren't aligned correctly when they have no parent