### PR TITLE
Only converting properties whose name end in 'color'

### DIFF
--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -177,6 +177,8 @@ class exports.LayerStates extends BaseClass
 
 		# TODO: Maybe we want to support advanced data structures like objects in the future too.
 		for k, v of properties
+			# We check if the property name ends with color, because we don't want
+			# to convert every string that looks like a Color, like the html property containing "add"
 			if _.isString(v) and _.endsWith(k.toLowerCase(),"color") and Color.isColorString(v)
 				stateProperties[k] = new Color(v)
 			else if _.isNumber(v) or _.isFunction(v) or _.isBoolean(v) or _.isString(v) or Color.isColorObject(v) or v == null

--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -177,8 +177,7 @@ class exports.LayerStates extends BaseClass
 
 		# TODO: Maybe we want to support advanced data structures like objects in the future too.
 		for k, v of properties
-
-			if _.isString(v) && _.endsWith(k.toLowerCase(),'color') && Color.isColorString(v)
+			if _.isString(v) and _.endsWith(k.toLowerCase(),"color") and Color.isColorString(v)
 				stateProperties[k] = new Color(v)
 			else if _.isNumber(v) or _.isFunction(v) or _.isBoolean(v) or _.isString(v) or Color.isColorObject(v) or v == null
 				stateProperties[k] = v

--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -85,7 +85,6 @@ class exports.LayerStates extends BaseClass
 
 			# Allow dynamic properties as functions
 			value = value.call(@layer, @layer, propertyName, stateName) if _.isFunction(value)
-
 			# Set the new value
 			properties[propertyName] = value
 
@@ -179,7 +178,7 @@ class exports.LayerStates extends BaseClass
 		# TODO: Maybe we want to support advanced data structures like objects in the future too.
 		for k, v of properties
 
-			if _.isString(v) && Color.isColorString(v)
+			if _.isString(v) && _.endsWith(k.toLowerCase(),'color') && Color.isColorString(v)
 				stateProperties[k] = new Color(v)
 			else if _.isNumber(v) or _.isFunction(v) or _.isBoolean(v) or _.isString(v) or Color.isColorObject(v) or v == null
 				stateProperties[k] = v

--- a/test/tests/LayerStatesTest.coffee
+++ b/test/tests/LayerStatesTest.coffee
@@ -51,6 +51,15 @@ describe "LayerStates", ->
 
 			Framer.resetDefaults()
 
+		it "should convert string to colors in states", ->
+			layer = new Layer
+			layer.states.add
+				test:
+					backgroundColor:"fff"
+					color: "000"
+			layer.states._states.test.backgroundColor.isEqual(new Color("fff")).should.be.true
+			layer.states._states.test.color.isEqual(new Color("000")).should.be.true
+
 
 
 	describe "Switch", ->
@@ -69,6 +78,12 @@ describe "LayerStates", ->
 			layer.states.switchInstant "stateB"
 			layer.states.current.should.equal "stateB"
 			layer.y.should.equal 123
+
+		it "should not change html when using switch instant", ->
+			layer = new Layer
+				html: "fff"
+			layer.states.switchInstant('default')
+			layer.html.should.equal "fff"
 
 
 	describe "Properties", ->


### PR DESCRIPTION
This caused a weird bug where the value of `html` would be replaced by a color string when in contained a color string (like "add")