### PR TITLE
Experiment: Router, Route, Link

### DIFF
--- a/framer/Framer.coffee
+++ b/framer/Framer.coffee
@@ -18,6 +18,9 @@ Framer.Screen = (require "./Screen").Screen
 Framer.Align = (require "./Align").Align
 Framer.MIDIControl = (require "./MIDIControl").MIDIControl
 Framer.print = (require "./Print").print
+Framer.Router = (require "./Router").Router
+Framer.Route = (require "./Route").Route
+Framer.Link = (require "./Link").Link
 
 # Components
 Framer.ScrollComponent = (require "./Components/ScrollComponent").ScrollComponent

--- a/framer/Link.coffee
+++ b/framer/Link.coffee
@@ -1,0 +1,12 @@
+{Layer} = require "./Layer"
+{Events} = require "./Events"
+
+class exports.Link extends Layer
+	constructor: (props) ->
+		super props
+		@router = props.router
+		@to = props.to
+		@on Events.Click, @clicked
+	# When you click a Link, change routes
+	clicked: () =>
+		@router.push(@to)

--- a/framer/Route.coffee
+++ b/framer/Route.coffee
@@ -1,0 +1,38 @@
+{Layer} = require "./Layer"
+{Screen} = require "./Screen"
+
+class exports.Route extends Layer
+	constructor: (props) ->
+		props.x ?= 0 # set default props
+		props.y ?= 0 # set default props
+		super(props)
+		@router = props.router
+		@visible = @router.route == @name
+		@width = Screen.width
+		@height = Screen.height
+#		@size = Screen
+		@onLeave = props.onLeave
+		@onEnter = props.onEnter
+		@router.on "routeWillChange", @handleRouteChange
+
+	handleOnLeave: () =>
+		@emit "routeDidLeave"
+		if @router.debug then print routeDidLeave: @name
+
+	handleOnEnter: () =>
+		@emit "routeDidEnter"
+		if @router.debug then print routeDidEnter: @name
+
+	handleRouteChange: () =>
+		if @router.lastRoute is @name
+			if @router.debug then print routeWillLeave: @name
+			@emit "routeWillLeave"
+			@ignoreEvents = true
+			if @onLeave then @onLeave(@handleOnLeave) else visible = false
+
+		if @router.nextRoute is @name
+			if @router.debug then print routeWillEnter: @name
+			@emit "routeWillEnter"
+			@ignoreEvents = false
+			@visible = true
+			if @onEnter then @onEnter(@handleOnEnter)

--- a/framer/Router.coffee
+++ b/framer/Router.coffee
@@ -1,0 +1,32 @@
+{BaseClass} = require "./BaseClass"
+
+class exports.Router extends BaseClass
+	constructor: (props) ->
+		props.debug ?= false
+		super()
+		@route = props.indexRoute
+		@debug = props.debug
+		@lastRoute = null
+		@nextRoute = null
+
+	push: (i) =>
+		unless @route is i
+			@lastRoute = @route
+			@nextRoute = i
+			if @debug
+				print
+					routeWillChange:
+						lastRoute: @lastRoute
+						nextRoute: @nextRoute
+
+			@emit "routeWillChange"
+			@route = i
+			@emit "routeDidChange" # could be interesting if you want.
+			if @debug then print routeDidChange: @route
+
+# @TODO:
+#	  goBack: () =>
+#	    handle history array
+#
+#	  replace: () =>
+#	    switch instantly to a route, perhaps no animations?


### PR DESCRIPTION
@koenbok this adds a declarative layer management solution (i.e. "router") to Framer. As we discussed last night at the Framer NYC event, I've been using it to scale from simple InVision-like flows to complex multi-view prototypes. My goal was to create an API that allows to users to more easily orchestrate and reason about intro/outro animations. 

### Demos
 - [Simple](http://share.framerjs.com/ql44rmd36tju/)
 - [Link API](http://share.framerjs.com/u2rvcvm0h2dq/)

### Module
- [framer-router](https://github.com/jaredpalmer/framer-router)

### Walkthrough
#### 1. Instantiate a new Router. Give it an indexRoute

```coffeescript
router = new Router
	indexRoute: 'RouteOne'
```

#### 2. Create a few routes and some child layers to go in them

```coffeescript
RouteOne = new Route
	router: router
	name: 'RouteOne'

RouteTwo = new Route
	router: router # connect it to your router
	name: 'RouteTwo' # give your route a name
	x: 755

```
#### 3. Make a link

```coffeescript
RouteOne.onClick () ->
	router.push('RouteTwo')

# Or, you can use the Link wrapper
Button = new Link
	router: router 
	to: 'RouteTwo' 
	parent: RouteOne
```

#### 4. Add Animations
By default, `Router` will just toggle visibilty. When you want to animate things, each `Route` has an optional `onEnter` and `onLeave` hook. Both `onEnter` and `onLeave` can call a callback function that simply emits `routeDidLeave` and `routeDidEnter` respectively.

```coffeescript
# You can use a state machine, or just the `animate` API to manage intros and outros

RouteOne.onEnter = () ->
	@animate
		properties:
			y: 0
			scale: 1
		curve: "spring(400,40,0)" 

RouteOne.onLeave = () ->
	@animate
		properties:
			y: 500
			scale: .5
		curve: "spring(400,60,0)"
...

RouteTwo.onEnter = (done) ->
	@animate
		properties:
			x: 0
		curve: "spring(400,40,0)"
	done() # emits 'routeDidEnter' event

RouteTwo.onLeave = (done) ->
	@animate
		properties:
			x: 755
		curve: "spring(400,60,0)"
	done() # emits 'routeDidLeave' event
```

### API
- `Router` - holds global view state
    - `indexRoute` - first route of the prototype
    - `Event::routeWillChange` - emitted before any route change
    - `Event::routeDidChange`  - emitted after any route change
- `Route` - wraps `Layer`, takes a `Router` and then exposes `onEnter` and `onLeave` hooks for animations
  - `router` - a parent router
  - `name` - name of the route
  - `onEnter(cb?)` - called when a route is about to be entered 
  - `onLeave(cb?)` - called when a route is about to be exited 
  - `Event::routeWillEnter` - emitted before route enters
  - `Event::routeDidEnter` - emitted after route enters only if `cb` is called within `onEnter` 
  - `Event::routeWillLeave` - emitted before route leaves 
  - `Event::routeDidLeave` - emitted after route leaves only if `cb` is called within `onLeave` 
- `Link` - wraps `Layer`, and attaches `onClick () -> router.push(to)`. Feel like React-Router's `<Link />` component

### Ideas / Questions 
 - it might make sense to modify `Router.push` and `Link.to` to accept data to pass to the next `Route`. See https://github.com/reactjs/react-router/blob/master/docs/API.md#to
 - Still working on the API, not sure about the current combo of hooks/event emmiters.