### PR TITLE
Feature/image load cancel

### DIFF
--- a/framer/Events.coffee
+++ b/framer/Events.coffee
@@ -42,6 +42,7 @@ Events.Scroll = "scroll"
 # Image events
 Events.ImageLoaded = "image:load"
 Events.ImageLoadError = "image:error"
+Events.ImageLoadCancelled = "image:cancelled"
 
 # Add all gesture events
 _.extend(Events, Gestures)

--- a/framer/Events.coffee
+++ b/framer/Events.coffee
@@ -40,9 +40,9 @@ Events.AnimationDidEnd = "end"
 Events.Scroll = "scroll"
 
 # Image events
-Events.ImageLoaded = "image:load"
-Events.ImageLoadError = "image:error"
-Events.ImageLoadCancelled = "image:cancelled"
+Events.ImageLoaded = "imageload"
+Events.ImageLoadError = "imageerror"
+Events.ImageLoadCancelled = "imagecancelled"
 
 # Add all gesture events
 _.extend(Events, Gestures)

--- a/framer/Events.coffee
+++ b/framer/Events.coffee
@@ -40,8 +40,8 @@ Events.AnimationDidEnd = "end"
 Events.Scroll = "scroll"
 
 # Image events
-Events.ImageLoaded = "load"
-Events.ImageLoadError = "error"
+Events.ImageLoaded = "image:load"
+Events.ImageLoadError = "image:error"
 
 # Add all gesture events
 _.extend(Events, Gestures)

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -681,10 +681,10 @@ class exports.Layer extends BaseClass
 			# As an optimization, we will only use a loader
 			# if something is explicitly listening to the load event
 
-			if @_domEventManager.listeners(Events.ImageLoaded)?.length > 0 or @_domEventManager.listeners(Events.ImageLoadError).length > 0
 				loader = new Image()
 				loader.name = imageUrl
 				loader.src = imageUrl
+			if @listeners(Events.ImageLoaded, true) or @listeners(Events.ImageLoadError, true) or @listeners(Events.ImageLoadCancelled, true)
 
 				loader.onload = =>
 					@style["background-image"] = "url('#{imageUrl}')"

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -662,7 +662,17 @@ class exports.Layer extends BaseClass
 			@_setPropertyValue("image", value)
 
 			if value in [null, ""]
+				if @imageLoader?
+					@imageLoader.onload = null
+					@imageLoader.onerror = null
+					@imageLoader.src = null
+
 				@style["background-image"] = null
+
+				if @imageLoader?
+					@emit Events.ImageLoadCancelled, @imageLoader
+					@imageLoader = null
+
 				return
 
 			# Show placeholder image on any browser that doesn't support inline pdf
@@ -681,17 +691,19 @@ class exports.Layer extends BaseClass
 			# As an optimization, we will only use a loader
 			# if something is explicitly listening to the load event
 
-				loader = new Image()
-				loader.name = imageUrl
-				loader.src = imageUrl
 			if @listeners(Events.ImageLoaded, true) or @listeners(Events.ImageLoadError, true) or @listeners(Events.ImageLoadCancelled, true)
+				@imageLoader = new Image()
+				@imageLoader.name = imageUrl
+				@imageLoader.src = imageUrl
 
-				loader.onload = =>
+				@imageLoader.onload = =>
 					@style["background-image"] = "url('#{imageUrl}')"
-					@emit Events.ImageLoaded, loader
+					@emit Events.ImageLoaded, @imageLoader
+					@imageLoader = null
 
-				loader.onerror = =>
-					@emit Events.ImageLoadError, loader
+				@imageLoader.onerror = =>
+					@emit Events.ImageLoadError, @imageLoader
+					@imageLoader = null
 
 			else
 				@style["background-image"] = "url('#{imageUrl}')"

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -639,6 +639,10 @@ class exports.Layer extends BaseClass
 	##############################################################
 	## IMAGE
 
+	cleanupImageLoader: ->
+		@imageLoader = null
+
+
 	@define "image",
 		default: ""
 		get: ->
@@ -671,7 +675,7 @@ class exports.Layer extends BaseClass
 
 				if @imageLoader?
 					@emit Events.ImageLoadCancelled, @imageLoader
-					@imageLoader = null
+					@cleanupImageLoader()
 
 				return
 
@@ -699,11 +703,11 @@ class exports.Layer extends BaseClass
 				@imageLoader.onload = =>
 					@style["background-image"] = "url('#{imageUrl}')"
 					@emit Events.ImageLoaded, @imageLoader
-					@imageLoader = null
+					@cleanupImageLoader()
 
 				@imageLoader.onerror = =>
 					@emit Events.ImageLoadError, @imageLoader
-					@imageLoader = null
+					@cleanupImageLoader()
 
 			else
 				@style["background-image"] = "url('#{imageUrl}')"

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -640,6 +640,8 @@ class exports.Layer extends BaseClass
 	## IMAGE
 
 	cleanupImageLoader: ->
+		@imageEventManager?.removeAllListeners()
+		@imageEventManager = null
 		@imageLoader = null
 
 
@@ -664,11 +666,9 @@ class exports.Layer extends BaseClass
 
 			# Set the property value
 			@_setPropertyValue("image", value)
-
 			if value in [null, ""]
 				if @imageLoader?
-					@imageLoader.onload = null
-					@imageLoader.onerror = null
+					@imageEventManager.removeAllListeners()
 					@imageLoader.src = null
 
 				@style["background-image"] = null
@@ -699,13 +699,13 @@ class exports.Layer extends BaseClass
 				@imageLoader = new Image()
 				@imageLoader.name = imageUrl
 				@imageLoader.src = imageUrl
-
-				@imageLoader.onload = =>
+				@imageEventManager = @_context.domEventManager.wrap(@imageLoader)
+				@imageEventManager.addEventListener "load", =>
 					@style["background-image"] = "url('#{imageUrl}')"
 					@emit Events.ImageLoaded, @imageLoader
 					@cleanupImageLoader()
 
-				@imageLoader.onerror = =>
+				@imageEventManager.addEventListener "error", =>
 					@emit Events.ImageLoadError, @imageLoader
 					@cleanupImageLoader()
 
@@ -1214,7 +1214,7 @@ class exports.Layer extends BaseClass
 			return false
 
 		if @_draggable
-			
+
 			if @_draggable.isDragging is false and @_draggable.isMoving is false
 				return false
 

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -639,10 +639,10 @@ class exports.Layer extends BaseClass
 	##############################################################
 	## IMAGE
 
-	cleanupImageLoader: ->
-		@imageEventManager?.removeAllListeners()
-		@imageEventManager = null
-		@imageLoader = null
+	_cleanupImageLoader: ->
+		@_imageEventManager?.removeAllListeners()
+		@_imageEventManager = null
+		@_imageLoader = null
 
 
 	@define "image",
@@ -667,15 +667,15 @@ class exports.Layer extends BaseClass
 			# Set the property value
 			@_setPropertyValue("image", value)
 			if value in [null, ""]
-				if @imageLoader?
-					@imageEventManager.removeAllListeners()
-					@imageLoader.src = null
+				if @_imageLoader?
+					@_imageEventManager.removeAllListeners()
+					@_imageLoader.src = null
 
 				@style["background-image"] = null
 
-				if @imageLoader?
-					@emit Events.ImageLoadCancelled, @imageLoader
-					@cleanupImageLoader()
+				if @_imageLoader?
+					@emit Events.ImageLoadCancelled, @_imageLoader
+					@_cleanupImageLoader()
 
 				return
 
@@ -696,18 +696,18 @@ class exports.Layer extends BaseClass
 			# if something is explicitly listening to the load event
 
 			if @listeners(Events.ImageLoaded, true) or @listeners(Events.ImageLoadError, true) or @listeners(Events.ImageLoadCancelled, true)
-				@imageLoader = new Image()
-				@imageLoader.name = imageUrl
-				@imageLoader.src = imageUrl
-				@imageEventManager = @_context.domEventManager.wrap(@imageLoader)
-				@imageEventManager.addEventListener "load", =>
+				@_imageLoader = new Image()
+				@_imageLoader.name = imageUrl
+				@_imageLoader.src = imageUrl
+				@_imageEventManager = @_context.domEventManager.wrap(@_imageLoader)
+				@_imageEventManager.addEventListener "load", =>
 					@style["background-image"] = "url('#{imageUrl}')"
-					@emit Events.ImageLoaded, @imageLoader
-					@cleanupImageLoader()
+					@emit Events.ImageLoaded, @_imageLoader
+					@_cleanupImageLoader()
 
-				@imageEventManager.addEventListener "error", =>
-					@emit Events.ImageLoadError, @imageLoader
-					@cleanupImageLoader()
+				@_imageEventManager.addEventListener "error", =>
+					@emit Events.ImageLoadError, @_imageLoader
+					@_cleanupImageLoader()
 
 			else
 				@style["background-image"] = "url('#{imageUrl}')"

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -1075,6 +1075,7 @@ class exports.Layer extends BaseClass
 
 	onImageLoaded: (cb) -> @on(Events.ImageLoaded, cb)
 	onImageLoadError: (cb) -> @on(Events.ImageLoadError, cb)
+	onImageLoadCancelled: (cb) -> @on(Events.ImageLoadCancelled, cb)
 
 	onMove: (cb) -> @on(Events.Move, cb)
 	onDragStart: (cb) -> @on(Events.DragStart, cb)

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -180,6 +180,28 @@ describe "Layer", ->
 			#layer.computedStyle()["background-size"].should.equal "cover"
 			#layer.computedStyle()["background-repeat"].should.equal "no-repeat"
 
+		it "should cancel loading when setting image to null", (done) ->
+			prefix = "../"
+			imagePath = "static/test.png"
+			fullPath = prefix + imagePath
+
+			#First set the image directly to something
+			layer = new Layer
+				image: "static/test2.png"
+
+			#Now add event handlers
+			layer.on Events.ImageLoadCancelled, ->
+				layer.style["background-image"].indexOf(imagePath).should.equal(-1)
+				layer.style["background-image"].indexOf("file://").should.equal(-1)
+				layer.style["background-image"].indexOf("?nocache=").should.equal(-1)
+				done()
+
+			#so we preload the next image
+			layer.image = fullPath
+
+			#set the image no null to cancel the loading
+			layer.image = null
+
 		it "should set image", ->
 			imagePath = "../static/test.png"
 			layer = new Layer image:imagePath


### PR DESCRIPTION
The problem: when setting using the image loader and setting the image to null afterwards, the loading wasn't cancelled, so the image would be set to the initial image when the loading finished.

This PR fixes that, and adds the possibility to listen to image cancel events.

I've changed the check for listeners from domEvent listeners to layer listeners, but maybe this has undesired side-effects that aren't currently clear to me.