### PR TITLE
Feature/point conversion proposal

### DIFF
--- a/framer/Canvas.coffee
+++ b/framer/Canvas.coffee
@@ -36,4 +36,13 @@ class Canvas extends BaseClass
 	toInspect: ->
 		return "<#{@constructor.name} #{@width}x#{@height}>"
 
+	# Point Conversion
+
+	convertPointToLayer: (point, layer) =>
+		return Utils.convertPointFromContext(point, layer, true, true)
+
+	convertPointToScreen: (point) =>
+		ctx = Framer.CurrentContext.device.context
+		return Utils.convertPointFromContext(point, ctx, true, true)
+
 exports.Canvas = Canvas

--- a/framer/Canvas.coffee
+++ b/framer/Canvas.coffee
@@ -38,11 +38,11 @@ class Canvas extends BaseClass
 
 	# Point Conversion
 
-	convertPointToLayer: (point, layer) =>
+	convertPointToLayer: (point, layer) ->
 		return Utils.convertPointFromContext(point, layer, true, true)
 
-	convertPointToScreen: (point) =>
-		ctx = Framer.CurrentContext.device.context
+	convertPointToScreen: (point) ->
+		ctx = Framer.Device.context
 		return Utils.convertPointFromContext(point, ctx, true, true)
 
 exports.Canvas = Canvas

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -400,16 +400,10 @@ class exports.Layer extends BaseClass
 		get: -> Utils.frameGetMaxY @
 		set: (value) -> Utils.frameSetMaxY @, value
 
-	convertPointFromScreen: (point) ->
-		return Utils.convertPointFromContext(point, @, false)
-
-	convertPointFromCanvas: (point) ->
-		return Utils.convertPointFromContext(point, @, true)
-
-	convertPointToScreen: (point) ->
+	convertPointToScreen: (point) =>
 		return Utils.convertPointToContext(point, @, false)
 
-	convertPointToCanvas: (point) ->
+	convertPointToCanvas: (point) =>
 		return Utils.convertPointToContext(point, @, true)
 
 	convertPointToLayer: (point, layer) =>

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -412,6 +412,9 @@ class exports.Layer extends BaseClass
 	convertPointToCanvas: (point) ->
 		return Utils.convertPointToContext(point, @, true)
 
+	convertPointToLayer: (point, layer) =>
+		return Utils.convertPoint(point, @, layer, true)
+
 	@define "canvasFrame",
 		importable: true
 		exportable: false

--- a/framer/Screen.coffee
+++ b/framer/Screen.coffee
@@ -24,6 +24,15 @@ class ScreenClass extends BaseClass
 	toInspect: ->
 		return "<Screen #{Utils.roundWhole(@width)}x#{Utils.roundWhole(@height)}>"
 
+	# Point Conversion
+
+	convertPointToLayer: (point, layer) =>
+		return Utils.convertPointFromContext(point, layer, false, true)
+
+	convertPointToCanvas: (point) =>
+		ctx = Framer.CurrentContext.device.context
+		return Utils.convertPointToContext(point, ctx, true, false)
+
 	# Edge Swipe
 
 	onEdgeSwipe:(cb) -> @on(Events.EdgeSwipe, cb)

--- a/framer/Screen.coffee
+++ b/framer/Screen.coffee
@@ -26,11 +26,11 @@ class ScreenClass extends BaseClass
 
 	# Point Conversion
 
-	convertPointToLayer: (point, layer) =>
+	convertPointToLayer: (point, layer) ->
 		return Utils.convertPointFromContext(point, layer, false, true)
 
-	convertPointToCanvas: (point) =>
-		ctx = Framer.CurrentContext.device.context
+	convertPointToCanvas: (point) ->
+		ctx = Framer.Device.context
 		return Utils.convertPointToContext(point, ctx, true, false)
 
 	# Edge Swipe

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -1148,7 +1148,7 @@ describe "Layer", ->
 
 	describe "Point conversion", ->
 
-		it "should correctly convert points to Screen", ->
+		it "should correctly convert points from layer to Screen", ->
 
 			point =
 				x: 200
@@ -1158,3 +1158,20 @@ describe "Layer", ->
 			screenPoint = layer.convertPointToScreen()
 			screenPoint.x.should.equal point.x
 			screenPoint.y.should.equal point.y
+
+		it "should correctly convert points from Screen to layer", ->
+
+			point =
+				x: 300
+				y: 200
+
+			layer = new Layer point: point
+			layerPoint = Screen.convertPointToLayer({}, layer)
+			layerPoint.x.should.equal -point.x
+			layerPoint.y.should.equal -point.y
+
+
+
+
+
+

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -1144,3 +1144,17 @@ describe "Layer", ->
 			a1.isAnimating.should.equal false
 			a2.isAnimating.should.equal false
 			a3.isAnimating.should.equal true
+
+
+	describe "Point conversion", ->
+
+		it "should correctly convert points to Screen", ->
+
+			point =
+				x: 200
+				y: 300
+
+			layer = new Layer point: point
+			screenPoint = layer.convertPointToScreen()
+			screenPoint.x.should.equal point.x
+			screenPoint.y.should.equal point.y

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -1170,8 +1170,32 @@ describe "Layer", ->
 			layerPoint.x.should.equal -point.x
 			layerPoint.y.should.equal -point.y
 
+		it "should correctly convert points from layer to layer", ->
 
+			layerBOffset =
+				x: 200
+				y: 400
 
+			layerA = new Layer
+			layerB = new Layer point: layerBOffset
 
+			layerAToLayerBPoint = layerA.convertPointToLayer({}, layerB)
+			layerAToLayerBPoint.x.should.equal -layerBOffset.x
+			layerAToLayerBPoint.y.should.equal -layerBOffset.y
 
+		it "should correctly convert points when layers are nested", ->
 
+			layerBOffset = 
+				x: 0
+				y: 200
+
+			layerA = new Layer
+			layerB = new Layer
+				parent: layerA
+				point: layerBOffset
+				rotation: 90
+				originX: 0
+				originY: 0
+
+			layerAToLayerBPoint = layerA.convertPointToLayer({}, layerB)
+			layerAToLayerBPoint.x.should.equal -layerBOffset.y


### PR DESCRIPTION
With this proposal we set out to:
- simplify the existing point conversion API
- make the API public (docs + autocomplete)

**Current API**

```coffee
Utils.convertPointToContext(point, layer, rootContext=false, includeLayer=true) -> point
Utils.convertPointFromContext(point, layer, rootContext=false, includeLayer=true) -> point

```

**Proposed API**
```coffee
Canvas.convertPointToLayer(point, layer) -> point
Screen.convertPointToLayer(point, layer) -> point

Canvas.convertPointToScreen(point) -> 		point
Screen.convertPointToCanvas(point) -> 		point

layer.convertPointToCanvas(point) -> 		point
layer.convertPointToScreen(point) -> 		point
layer.convertPointToLayer(point, layer) -> 	point
```
All conversions start as a function on the instance you are converting from. Points are always the first parameter. This parameter defaults to `{x:0, y:0}`.
When you are converting to a layer this needs to be specified as the second parameter.