### PR TITLE
Fix Framer.resetDefaults

### DIFF
--- a/framer/Defaults.coffee
+++ b/framer/Defaults.coffee
@@ -87,8 +87,7 @@ exports.Defaults =
 		options = _.clone options
 
 		# Always start with the originals
-		defaults = _.clone Originals[className]
-
+		defaults = _.cloneDeep Originals[className]
 		# Copy over the user defined options
 		for k, v of Framer.Defaults[className]
 			defaults[k] = if _.isFunction(v) then v() else v
@@ -114,4 +113,4 @@ exports.Defaults =
 		exports.Defaults.reset()
 
 	reset: ->
-		window.Framer.Defaults = _.clone Originals
+		window.Framer.Defaults = _.cloneDeep Originals

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -1,8 +1,14 @@
 window.chai = require("chai")
 
-# We don't want to update all the tests if we change these
-Framer.Defaults.Layer.width = 100
-Framer.Defaults.Layer.height = 100
+
+previousReset = Framer.resetDefaults
+
+Framer.resetDefaults = ->
+	previousReset()
+	# We don't want to update all the tests if we change these
+	Framer.Defaults.Layer.width = 100
+	Framer.Defaults.Layer.height = 100
+Framer.resetDefaults()
 
 window.console.debug = (v) ->
 window.console.warn = (v) ->

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -16,22 +16,25 @@ describe "Layer", ->
 			Framer.resetDefaults()
 			Framer.Defaults.DeviceComponent.animationOptions.curve.should.equal "ease-in-out"
 
+		it "should set defaults", ->
+			width = Utils.randomNumber(0,400)
+			height = Utils.randomNumber(0,400)
 			Framer.Defaults =
 				Layer:
-					width: 200
-					height: 200
+					width: width
+					height: height
+
 
 			layer = new Layer()
 
-			layer.width.should.equal 200
-			layer.height.should.equal 200
+			layer.width.should.equal width
+			layer.height.should.equal height
 
 			Framer.resetDefaults()
 
 			layer = new Layer()
-
-			layer.width.should.equal 100
-			layer.height.should.equal 100
+			layer.width.should.equal 200
+			layer.height.should.equal 200
 
 		it "should set default background color", ->
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -11,7 +11,10 @@ describe "Layer", ->
 
 	describe "Defaults", ->
 
-		it "should set defaults", ->
+		it "should reset nested defaults defaults", ->
+			Framer.Defaults.DeviceComponent.animationOptions.curve = "spring"
+			Framer.resetDefaults()
+			Framer.Defaults.DeviceComponent.animationOptions.curve.should.equal "ease-in-out"
 
 			Framer.Defaults =
 				Layer:

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -11,7 +11,7 @@ describe "Layer", ->
 
 	describe "Defaults", ->
 
-		it "should reset nested defaults defaults", ->
+		it "should reset nested defaults", ->
 			Framer.Defaults.DeviceComponent.animationOptions.curve = "spring"
 			Framer.resetDefaults()
 			Framer.Defaults.DeviceComponent.animationOptions.curve.should.equal "ease-in-out"

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -16,6 +16,15 @@ describe "Layer", ->
 			Framer.resetDefaults()
 			Framer.Defaults.DeviceComponent.animationOptions.curve.should.equal "ease-in-out"
 
+		it "should reset width and height to their previous values", ->
+			previousWidth = Framer.Defaults.Layer.width
+			previousHeight = Framer.Defaults.Layer.height
+			Framer.Defaults.Layer.width = 123
+			Framer.Defaults.Layer.height = 123
+			Framer.resetDefaults()
+			Framer.Defaults.Layer.width.should.equal previousWidth
+			Framer.Defaults.Layer.height.should.equal previousHeight
+
 		it "should set defaults", ->
 			width = Utils.randomNumber(0,400)
 			height = Utils.randomNumber(0,400)
@@ -23,7 +32,6 @@ describe "Layer", ->
 				Layer:
 					width: width
 					height: height
-
 
 			layer = new Layer()
 
@@ -33,8 +41,8 @@ describe "Layer", ->
 			Framer.resetDefaults()
 
 			layer = new Layer()
-			layer.width.should.equal 200
-			layer.height.should.equal 200
+			layer.width.should.equal 100
+			layer.height.should.equal 100
 
 		it "should set default background color", ->
 


### PR DESCRIPTION
Turns out, because of a non-deep clone, in some cases the original Framer.Defaults were overwritten, and not correctly reset when calling `Framer.resetDefaults()`. 

This fixes that, and adds a special override to resetDefaults for the tests, so we can keep using a default layer size of 100x100