### PR TITLE
Remove invalid use of __framerInstance

### DIFF
--- a/framer/Components/ScrollComponent.coffee
+++ b/framer/Components/ScrollComponent.coffee
@@ -434,14 +434,14 @@ wrapComponent = (instance, layer, options = {correct:true}) ->
 	scroll.parent = layer.parent
 	scroll.index = layer.index
 
-	# Copy over the name, if we don't have it try to use the variable
-	# name from Framer Studio if it was given.
+	# Copy over the name
 	if isPageComponent
 		scroll.name = instance.constructor.name
 	else if layer.name and layer.name isnt ""
 		scroll.name = layer.name
 	else if layer.__framerInstanceInfo?.name
-		scroll.name = layer.__framerInstanceInfo.name
+		scroll.__framerInstanceInfo ?= {}
+		scroll.__framerInstanceInfo?.name = layer.__framerInstanceInfo.name
 
 	# If we have an image set, it makes way more sense to add it to the
 	# background of the wrapper then the content.

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -239,9 +239,7 @@ class exports.Layer extends BaseClass
 		default: ""
 		get: ->
 			name = @_getPropertyValue("name")
-			return name if name
-			# In Framer Studio, we can use the variable name
-			return @__framerInstanceInfo?.name or ""
+			return name or ""
 
 		set: (value) ->
 			@_setPropertyValue("name", value)

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -1320,6 +1320,7 @@ class exports.Layer extends BaseClass
 	toInspect: (constructor) ->
 		constructor ?= @constructor.name
 		name = if @name then "name:#{@name} " else ""
-		return "<#{constructor} id:#{@id} #{name}
+		variablename = @__framerInstanceInfo?.name or ""
+		return "<#{constructor} #{variablename} id:#{@id} #{name}
 			(#{Utils.roundWhole(@x)},#{Utils.roundWhole(@y)})
 			#{Utils.roundWhole(@width)}x#{Utils.roundWhole(@height)}>"

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -450,6 +450,11 @@ describe "Layer", ->
 			layer.rotation.should.equal(100)
 			layer.rotationZ.should.equal(100)
 
+		it "should only set name when explicitly set", ->
+			layer = new Layer
+			layer.__framerInstanceInfo = {name:"aap"}
+			layer.name.should.equal ""
+
 
 
 	describe "Filter Properties", ->

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -455,6 +455,10 @@ describe "Layer", ->
 			layer.__framerInstanceInfo = {name:"aap"}
 			layer.name.should.equal ""
 
+		it "it should show the variable name in toInspect()", ->
+			layer = new Layer
+			layer.__framerInstanceInfo = {name:"aap"}
+			layer.toInspect().should.equal "<Layer aap id:89  (0,0) 100x100>"
 
 
 	describe "Filter Properties", ->

--- a/test/tests/ScrollComponentTest.coffee
+++ b/test/tests/ScrollComponentTest.coffee
@@ -107,6 +107,23 @@ describe "ScrollComponent", ->
 			scroll = new ScrollComponent()
 			scroll.content.clip.should.equal true
 
+		it "should copy over __framerInstanceInfo", ->
+			aap = new Layer
+			aap.__framerInstanceInfo = {name: "aap"}
+			bla = new Layer
+				parent: aap
+			scroll = ScrollComponent.wrap(aap)
+			scroll.__framerInstanceInfo.name.should.equal "aap"
+
+		it "should not copy over framerInstanceInfo to name", ->
+			aap = new Layer
+			aap.__framerInstanceInfo = {name: "aap"}
+			bla = new Layer
+				parent: aap
+			scroll = ScrollComponent.wrap(aap)
+			scroll.name.should.not.equal "aap"
+
+
 		it "should set the right content size for added pages by constructor", ->
 
 			# Constructors depend on different things for size, align and parent. Sometimes


### PR DESCRIPTION
__framerInstance is only available through the Inferencer in Framer Studio, so we should never use it the change other properties of Framer objects.
We can, however use it to give more sensible debug output when using `toInspect()`

This PR does both.