### PR TITLE
Enable native Touch events again when disabling the TouchEmulator

### DIFF
--- a/framer/Events.coffee
+++ b/framer/Events.coffee
@@ -5,11 +5,6 @@ Utils = require "./Utils"
 
 Events = {}
 
-# Standard touch events
-Events.TouchStart = "touchstart"
-Events.TouchEnd = "touchend"
-Events.TouchMove = "touchmove"
-
 # Standard dom events
 Events.MouseUp = "mouseup"
 Events.MouseDown = "mousedown"
@@ -20,11 +15,22 @@ Events.MouseWheel = "mousewheel"
 Events.DoubleClick = "dblclick"
 Events.MouseDoubleClick = "dblclick" # Alias for consistent naming
 
+# Standard touch events
+Events.enableEmulatedTouchEvents = (enable=true) ->
+	if enable
+		Events.TouchStart = Events.MouseDown
+		Events.TouchEnd = Events.MouseUp
+		Events.TouchMove = Events.MouseMove
+	else
+		Events.TouchStart = "touchstart"
+		Events.TouchEnd = "touchend"
+		Events.TouchMove = "touchmove"
+
+Events.enableEmulatedTouchEvents(false)
+
 # Let's make sure the touch events work on desktop too
 if not Utils.isTouch()
-	Events.TouchStart = Events.MouseDown
-	Events.TouchEnd = Events.MouseUp
-	Events.TouchMove = Events.MouseMove
+	Events.enableEmulatedTouchEvents()
 
 Events.Click = Events.TouchEnd
 

--- a/framer/Extras/TouchEmulator.coffee
+++ b/framer/Extras/TouchEmulator.coffee
@@ -224,8 +224,10 @@ touchEmulator = null
 exports.enable = ->
 	return if Utils.isTouch()
 	touchEmulator ?= new TouchEmulator()
+	Events.enableEmulatedTouchEvents(true)
 
 exports.disable = ->
 	return unless touchEmulator
 	touchEmulator.destroy()
 	touchEmulator = null
+	Events.enableEmulatedTouchEvents(false)


### PR DESCRIPTION
This implements changes discussed in #245 