### PR TITLE
Improve support for custom devices

### DIFF
--- a/extras/Studio.framer/app.coffee
+++ b/extras/Studio.framer/app.coffee
@@ -1,18 +1,12 @@
 
-# Define custom device
-Framer.DeviceView.Devices["a"] =
-	"deviceType": "tablet"
-	"screenWidth": 720
-	"screenHeight": 1000
-	"deviceImage": "http://f.cl.ly/items/001L0v3c1f120t0p2z24/custom.png"
-	"deviceImageWidth": 800
-	"deviceImageHeight": 1214
 
-# Set custom device
-Framer.Device.deviceType = "a"
-
-layerA = new Layer
-	backgroundColor: "white"
+Device.customize
+	deviceType: Device.Type.Tablet
+	screenWidth: 720
+	screenHeight: 1024
+	deviceImage: "http://f.cl.ly/items/001L0v3c1f120t0p2z24/custom.png"
+	deviceImageWidth: 800
+	deviceImageHeight: 1214
 
 Screen.backgroundColor = "28affa"
 

--- a/extras/Studio.framer/app.coffee
+++ b/extras/Studio.framer/app.coffee
@@ -1,17 +1,18 @@
-# Framer.Extras.Hints.disable()
 
-Framer.Info =
-	title: ""
-	author: "Koen Bok"
-	twitter: ""
-	description: ""
+# Define custom device
+Framer.DeviceView.Devices["a"] =
+	"deviceType": "tablet"
+	"screenWidth": 720
+	"screenHeight": 1000
+	"deviceImage": "http://f.cl.ly/items/001L0v3c1f120t0p2z24/custom.png"
+	"deviceImageWidth": 800
+	"deviceImageHeight": 1214
 
-# Framer.Extras.Preloader.enable()
+# Set custom device
+Framer.Device.deviceType = "a"
 
-grid = new GridComponent
-	size: Screen
+layerA = new Layer
+	backgroundColor: "white"
 
-grid.renderCell = (layer) ->
-	layer.image = Utils.randomImage(layer) + "cache=#{Date.now()}"
-	
-	layer.onTap ->
+Screen.backgroundColor = "28affa"
+

--- a/extras/Studio.framer/framer/config.json
+++ b/extras/Studio.framer/framer/config.json
@@ -2,16 +2,16 @@
   "propertyPanelToggleStates" : {
     "Filters" : false
   },
-  "deviceOrientation" : 90,
+  "deviceOrientation" : 0,
   "sharedPrototype" : 1,
   "contentScale" : 1,
-  "deviceType" : "apple-iphone-5s-silver",
+  "deviceType" : "custom",
   "selectedHand" : "iphone-hands-1",
   "updateDelay" : 0.3,
   "deviceScale" : "fit",
   "foldedCodeRanges" : [
 
   ],
-  "orientation" : 90,
+  "orientation" : 0,
   "fullScreen" : false
 }

--- a/extras/Studio.framer/framer/config.json
+++ b/extras/Studio.framer/framer/config.json
@@ -1,17 +1,17 @@
 {
   "propertyPanelToggleStates" : {
-
+    "Filters" : false
   },
-  "deviceOrientation" : 0,
+  "deviceOrientation" : 90,
   "sharedPrototype" : 1,
   "contentScale" : 1,
-  "deviceType" : "apple-iphone-5s-gold",
-  "selectedHand" : "iphone-hands-2",
+  "deviceType" : "apple-iphone-5s-silver",
+  "selectedHand" : "iphone-hands-1",
   "updateDelay" : 0.3,
   "deviceScale" : "fit",
   "foldedCodeRanges" : [
 
   ],
-  "orientation" : 0,
+  "orientation" : 90,
   "fullScreen" : false
 }

--- a/framer/Components/DeviceComponent.coffee
+++ b/framer/Components/DeviceComponent.coffee
@@ -59,6 +59,11 @@ class exports.DeviceComponent extends BaseClass
 
 		_.extend(@, _.defaults(options, defaults))
 
+		@Type =
+			Tablet: "tablet"
+			Phone: "phone"
+			Browser: "browser"
+
 	_setup: ->
 
 		if @_setupDone
@@ -229,8 +234,8 @@ class exports.DeviceComponent extends BaseClass
 	###########################################################################
 	# DEVICE TYPE
 
-	customDevice: (deviceProps) =>
-		Devices["custom"] = _.defaults deviceProps, Devices["custom"]
+	customize: (deviceProps) =>
+		Devices.custom = _.defaults deviceProps, Devices.custom
 		@deviceType = "custom"
 
 	@define "deviceType",

--- a/framer/Components/DeviceComponent.coffee
+++ b/framer/Components/DeviceComponent.coffee
@@ -229,6 +229,10 @@ class exports.DeviceComponent extends BaseClass
 	###########################################################################
 	# DEVICE TYPE
 
+	customDevice: (deviceProps) =>
+		Devices["custom"] = _.defaults deviceProps, Devices["custom"]
+		@deviceType = "custom"
+
 	@define "deviceType",
 		get: ->
 			@_deviceType

--- a/framer/Components/DeviceComponent.coffee
+++ b/framer/Components/DeviceComponent.coffee
@@ -234,7 +234,7 @@ class exports.DeviceComponent extends BaseClass
 			@_deviceType
 		set: (deviceType) ->
 
-			if deviceType is @_deviceType
+			if deviceType is @_deviceType and deviceType isnt "custom"
 				return
 
 			device = null
@@ -263,6 +263,8 @@ class exports.DeviceComponent extends BaseClass
 			@_updateDeviceImage()
 			@_update()
 			@emit("change:deviceType")
+
+			@viewport.point = @_viewportOrientationOffset()
 
 			if shouldZoomToFit
 				@deviceScale = "fit"
@@ -459,24 +461,7 @@ class exports.DeviceComponent extends BaseClass
 			rotationZ: -@_orientation
 			scale: @_calculatePhoneScale()
 
-		[width, height] = @_getOrientationDimensions(@_device.screenWidth, @_device.screenHeight)
-
-		@content.width = width
-		@content.height = height
-
-		offset = (@screen.width - width) / 2
-		offset *= -1 if @_orientation == -90
-
-		[x, y] = [0, 0]
-
-		if @isLandscape
-			x = offset
-			y = offset
-
-		contentProperties =
-			rotationZ: @_orientation
-			x: x
-			y: y
+		contentProperties = @_viewportOrientationOffset()
 
 		@hands.animateStop()
 		@viewport.animateStop()
@@ -498,6 +483,27 @@ class exports.DeviceComponent extends BaseClass
 		@handsImageLayer.image = "" if @_orientation != 0
 
 		@emit("change:orientation", @_orientation)
+
+	_viewportOrientationOffset: =>
+
+		[width, height] = @_getOrientationDimensions(@_device.screenWidth, @_device.screenHeight)
+
+		@content.width = width
+		@content.height = height
+
+		offset = (@screen.width - width) / 2
+		offset *= -1 if @_orientation == -90
+
+		[x, y] = [0, 0]
+
+		if @isLandscape
+			x = offset
+			y = offset
+
+		return contentProperties =
+			rotationZ: @_orientation
+			x: x
+			y: y
 
 	_orientationChange: =>
 		@_orientation = window.orientation
@@ -990,6 +996,14 @@ Devices =
 		name: "Fullscreen"
 		deviceType: "desktop"
 		backgroundColor: "white"
+
+	"custom":
+		name: "Custom"
+		deviceImageWidth: 874
+		deviceImageHeight: 1792
+		screenWidth: 750
+		screenHeight: 1334
+		deviceType: "phone"
 
 	# iPad Air
 	"apple-ipad-air-2-silver": _.clone(iPadAir2BaseDevice)


### PR DESCRIPTION
- New convenience method to customize the device.
- Adds a default custom device which can be overridden. This allows Framer for Mac to enable the zooming and orientation controls for custom devices.

Old:
```coffee
# Define custom device		
Framer.DeviceView.Devices["custom"] =		
	"deviceType": "phone"		
	"screenWidth": 720		
	"screenHeight": 1000		
	"deviceImage": "http://f.cl.ly/items/001L0v3c1f120t0p2z24/custom.png"		
	"deviceImageWidth": 800		
	"deviceImageHeight": 1214		

# Set custom device		
Framer.Device.deviceType = "custom"
```

New:
```coffee
# Define and set custom device
Framer.Device.customize
	deviceType: Framer.Device.Type.Tablet
	screenWidth: 720
	screenHeight: 1024
	deviceImage: "http://f.cl.ly/items/001L0v3c1f120t0p2z24/custom.png"
	deviceImageWidth: 800
	deviceImageHeight: 1214
```