### PR TITLE
fix video layer for ios 10

### DIFF
--- a/framer/VideoLayer.coffee
+++ b/framer/VideoLayer.coffee
@@ -7,6 +7,7 @@ class exports.VideoLayer extends Layer
 		# We need the player to exist before we add the options
 		@player = document.createElement("video")
 		@player.setAttribute("webkit-playsinline", "true")
+		@player.setAttribute("playsinline", "")
 		@player.style.width = "100%"
 		@player.style.height = "100%"
 


### PR DESCRIPTION
playslinline is no longer prefixed on iOS 10. this should allow it to work on iOS 10 and previous versions

i dont think i'll break anything this time @koenbok 