### PR TITLE
Optimizations

### DIFF
--- a/framer/BaseClass.coffee
+++ b/framer/BaseClass.coffee
@@ -23,19 +23,7 @@ class exports.BaseClass extends EventEmitter
 		if @ isnt BaseClass
 			@_addDescriptor(propertyName, descriptor)
 
-		# Set the getter/setter as setProperty on this object so we can access and override it easily
-		getName = "get#{capitalizeFirstLetter(propertyName)}"
-		@::[getName] = descriptor.get
-		descriptor.get = @::[getName]
-
-		if descriptor.set
-			setName = "set#{capitalizeFirstLetter(propertyName)}"
-			@::[setName] = descriptor.set
-			descriptor.set = @::[setName]
-
-		# Better readonly errors for debugging
-
-		# else
+		# if not descriptor.set
 		# 	descriptor.set = (value) ->
 		# 		throw Error("#{@constructor.name}.#{propertyName} is readonly")
 

--- a/framer/BaseClass.coffee
+++ b/framer/BaseClass.coffee
@@ -9,9 +9,6 @@ DefinedPropertiesKey = "_DefinedPropertiesKey"
 DefinedPropertiesValuesKey = "_DefinedPropertiesValuesKey"
 DefinedPropertiesOrderKey = "_DefinedPropertiesOrderKey"
 
-capitalizeFirstLetter = (string) ->
-	string.charAt(0).toUpperCase() + string.slice(1)
-
 class exports.BaseClass extends EventEmitter
 
 	#################################################################
@@ -23,11 +20,11 @@ class exports.BaseClass extends EventEmitter
 		if @ isnt BaseClass
 			@_addDescriptor(propertyName, descriptor)
 
-		# if not descriptor.set
-		# 	descriptor.set = (value) ->
-		# 		throw Error("#{@constructor.name}.#{propertyName} is readonly")
+		if not descriptor.set?
+			descriptor.set = (value) ->
+				throw Error("#{@constructor.name}.#{propertyName} is readonly")
 
-		# Define the property
+		# Define the property on the prototype
 		Object.defineProperty(@prototype, propertyName, descriptor)
 
 	@_addDescriptor: (propertyName, descriptor) ->

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -53,7 +53,7 @@ layerProperty = (obj, name, cssProperty, fallback, validator, transformer, optio
 
 			# We try to not send any events while we run the constructor, it just
 			# doesn't make sense, because no one can listen to use yet.
-			return if @__constructing
+			return if @__constructor
 
 			@emit("change:#{name}", value)
 			@emit("change:point", value) if name in ["x", "y"]
@@ -84,9 +84,9 @@ class exports.Layer extends BaseClass
 	constructor: (options={}) ->
 
 		# Make sure we never call the constructor twice
-		throw Error("Layer.constructor #{@toInspect()} called twice") if @__constructed
-		@__constructed = true
-		@__constructing = true
+		throw Error("Layer.constructor #{@toInspect()} called twice") if @__constructorCalled
+		@__constructorCalled = true
+		@__constructor = true
 
 		# Set needed private variables
 		@_properties = {}
@@ -142,7 +142,7 @@ class exports.Layer extends BaseClass
 		@_stateMachine = new LayerStateMachine(@)
 		@_context.emit("layer:create", @)
 
-		delete @__constructing
+		delete @__constructor
 
 	##############################################################
 	# Properties

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -50,6 +50,11 @@ layerProperty = (obj, name, cssProperty, fallback, validator, transformer, optio
 				@_element.style[cssProperty] = LayerStyle[cssProperty](@)
 
 			set?(@, value)
+
+			# We try to not send any events while we run the constructor, it just
+			# doesn't make sense, because no one can listen to use yet.
+			return if @__constructing
+
 			@emit("change:#{name}", value)
 			@emit("change:point", value) if name in ["x", "y"]
 			@emit("change:size", value)  if name in ["width", "height"]
@@ -81,6 +86,7 @@ class exports.Layer extends BaseClass
 		# Make sure we never call the constructor twice
 		throw Error("Layer.constructor #{@toInspect()} called twice") if @__constructed
 		@__constructed = true
+		@__constructing = true
 
 		# Set needed private variables
 		@_properties = {}
@@ -135,6 +141,8 @@ class exports.Layer extends BaseClass
 		@animationOptions = {}
 		@_stateMachine = new LayerStateMachine(@)
 		@_context.emit("layer:create", @)
+
+		delete @__constructing
 
 	##############################################################
 	# Properties
@@ -777,7 +785,7 @@ class exports.Layer extends BaseClass
 
 			# If there is no parent we need to walk through the root
 			if @parent is null
-				return _.filter @_context.getLayers(), (layer) =>
+				return _.filter @_context.layers, (layer) =>
 					layer isnt @ and layer.parent is null
 
 			return _.without @parent.children, @

--- a/test/tests/BaseClassTest.coffee
+++ b/test/tests/BaseClassTest.coffee
@@ -186,7 +186,7 @@ describe "BaseClass", ->
 				get: () -> "value"
 
 		instance = new TestClass()
-		(-> instance.testProp = "foo").should.throw "setting a property that has only a getter"
+		(-> instance.testProp = "foo").should.throw "TestClass.testProp is readonly"
 
 	it "should not set read-only prop via props setter", ->
 

--- a/test/tests/BaseClassTest.coffee
+++ b/test/tests/BaseClassTest.coffee
@@ -107,29 +107,29 @@ describe "BaseClass", ->
 		testClass = new TestClass3()
 		testClass.keys().should.eql ["testA", "testB"]
 
-	it "should create getters/setters", ->
+	# it "should create getters/setters", ->
 
-		class TestClass4 extends Framer.BaseClass
-			@define "testA", @simpleProperty "testA", 100
+	# 	class TestClass4 extends Framer.BaseClass
+	# 		@define "testA", @simpleProperty "testA", 100
 
-		testClass = new TestClass4()
-		testClass.setTestA(500)
-		testClass.getTestA().should.equal 500
-		testClass.testA.should.equal 500
+	# 	testClass = new TestClass4()
+	# 	testClass.setTestA(500)
+	# 	testClass.getTestA().should.equal 500
+	# 	testClass.testA.should.equal 500
 
-	it "should override getters/setters", ->
+	# it "should override getters/setters", ->
 
-		class TestClass5 extends Framer.BaseClass
-			@define "testA", @simpleProperty "testA", 100
+	# 	class TestClass5 extends Framer.BaseClass
+	# 		@define "testA", @simpleProperty "testA", 100
 
-		class TestClass6 extends TestClass5
-			setTestA: (value) ->
-				super value * 10
+	# 	class TestClass6 extends TestClass5
+	# 		setTestA: (value) ->
+	# 			super value * 10
 
-		testClass = new TestClass6()
-		testClass.setTestA(500)
-		testClass.getTestA().should.equal 5000
-		testClass.testA.should.equal 5000
+	# 	testClass = new TestClass6()
+	# 	testClass.setTestA(500)
+	# 	testClass.getTestA().should.equal 5000
+	# 	testClass.testA.should.equal 5000
 
 	it "should work with proxyProperties", ->
 

--- a/test/tests/ContextTest.coffee
+++ b/test/tests/ContextTest.coffee
@@ -219,7 +219,7 @@ describe "Context", ->
 
 			context = new Framer.Context(name:"Test")
 			context.on "layer:create", ->
-				context.getLayers().length.should.equal 1
+				context.layers.length.should.equal 1
 				callback()
 
 			context.run ->
@@ -231,10 +231,10 @@ describe "Context", ->
 			context = new Framer.Context(name:"Test")
 
 			context.on "layer:create", ->
-				context.getLayers().length.should.equal 1
+				context.layers.length.should.equal 1
 
 			context.on "layer:destroy", ->
-				context.getLayers().length.should.equal 0
+				context.layers.length.should.equal 0
 				callback()
 
 			context.run ->

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -982,7 +982,7 @@ describe "Layer", ->
 			layer = new Layer
 			layer.destroy()
 
-			(layer in Framer.CurrentContext.getLayers()).should.be.false
+			(layer in Framer.CurrentContext.layers).should.be.false
 			assert.equal layer._element.parentNode, null
 
 		it "should set text", ->

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -525,7 +525,7 @@ describe "Layer", ->
 			layer.shadowBlur.should.equal 10
 			layer.shadowSpread.should.equal 10
 
-			layer.style.boxShadow.should.equal "rgba(123, 123, 123, 0.496094) 10px 10px 10px 10px"
+			layer.style.boxShadow.should.equal "rgba(123, 123, 123, 0.498039) 10px 10px 10px 10px"
 
 			# Only after we set a color a shadow should be drawn
 			layer.shadowColor = "red"


### PR DESCRIPTION
A sweet little PR that should increase performance and save memory:

- Don't send events in the `Layer` constructor.
- Don't use explicit named setters/getters in `BaseClass`.

All tests pass.