### PR TITLE
Feature/remove undocument deprecated api

### DIFF
--- a/framer/LayerStateMachine.coffee
+++ b/framer/LayerStateMachine.coffee
@@ -36,6 +36,9 @@ class exports.LayerStateMachine extends BaseClass
 		# Check if the state exists, if not this is a pretty serious error
 		throw Error "No such state: '#{stateName}'" unless @states[stateName]
 
+		if stateName == "previous"
+			stateName = @previousName
+
 		# Prep the properties and the options. The options come from the state, and can be overriden
 		# with the function arguments here.
 		properties = _.clone(@states[stateName])

--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -117,13 +117,6 @@ class LayerStates
 			deprecatedWarning("states", "layer.stateNames")
 			@machine.stateNames
 
-		animatingKeys: ->
-			deprecatedWarning("animatingKeys")
-			keys = []
-			for name, state of @
-				keys = _.union(keys, _.keys(state))
-			return keys
-
 		next: (options...) ->
 			deprecatedWarning("next", "layer.stateCycle()")
 			options = _.flatten(options)
@@ -140,7 +133,6 @@ class LayerStates
 	@defineReserved "remove", get: -> methods.remove
 	@defineReserved "switch", get: -> methods.switch
 	@defineReserved "switchInstant", get: -> methods.switchInstant
-	@defineReserved "animatingKeys", get: -> methods.animatingKeys
 	@defineReserved "next", get: -> methods.next
 	@defineReserved "last", get: -> methods.last
 	@defineReserved "state", get: methods.state

--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -105,18 +105,6 @@ class LayerStates
 			deprecatedWarning("state", "layer.states.current.name")
 			@machine.currentName
 
-		all: ->
-			deprecatedWarning("all", "layer.stateNames")
-			@machine.stateNames
-
-		stateNames: ->
-			deprecatedWarning("stateNames", "layer.stateNames")
-			@machine.stateNames
-
-		states: ->
-			deprecatedWarning("states", "layer.stateNames")
-			@machine.stateNames
-
 		next: (options...) ->
 			deprecatedWarning("next", "layer.stateCycle()")
 			options = _.flatten(options)
@@ -136,9 +124,6 @@ class LayerStates
 	@defineReserved "next", get: -> methods.next
 	@defineReserved "last", get: -> methods.last
 	@defineReserved "state", get: methods.state
-	@defineReserved "all", get: methods.all
-	@defineReserved "stateNames", get: methods.stateNames
-	@defineReserved "states", get: methods.states
 	@defineReserved "on", get: -> methods.on
 	@defineReserved "animationOptions",
 		get: -> @machine.layer.animationOptions

--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -101,10 +101,6 @@ class LayerStates
 			deprecatedWarning("switchInstant", "layer.animate(\"state\", {instant: true})")
 			@machine.switchTo(stateName, {instant: true})
 
-		state: ->
-			deprecatedWarning("state", "layer.states.current.name")
-			@machine.currentName
-
 		next: (options...) ->
 			deprecatedWarning("next", "layer.stateCycle()")
 			options = _.flatten(options)
@@ -118,7 +114,6 @@ class LayerStates
 	@defineReserved "switch", get: -> methods.switch
 	@defineReserved "switchInstant", get: -> methods.switchInstant
 	@defineReserved "next", get: -> methods.next
-	@defineReserved "state", get: methods.state
 	@defineReserved "on", get: -> methods.on
 	@defineReserved "animationOptions",
 		get: -> @machine.layer.animationOptions

--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -106,15 +106,11 @@ class LayerStates
 			options = _.flatten(options)
 			@machine.layer.stateCycle(options)
 
-		on: (eventName, handler) ->
-			@machine.on(eventName, handler)
-
 	@defineReserved "add", get: -> methods.add
 	@defineReserved "remove", get: -> methods.remove
 	@defineReserved "switch", get: -> methods.switch
 	@defineReserved "switchInstant", get: -> methods.switchInstant
 	@defineReserved "next", get: -> methods.next
-	@defineReserved "on", get: -> methods.on
 	@defineReserved "animationOptions",
 		get: -> @machine.layer.animationOptions
 		set: (options) -> @machine.layer.animationOptions = options

--- a/framer/LayerStates.coffee
+++ b/framer/LayerStates.coffee
@@ -110,10 +110,6 @@ class LayerStates
 			options = _.flatten(options)
 			@machine.layer.stateCycle(options)
 
-		last: (options) ->
-			deprecatedWarning("last")
-			@machine.switchTo(@machine.previousName, options)
-
 		on: (eventName, handler) ->
 			@machine.on(eventName, handler)
 
@@ -122,7 +118,6 @@ class LayerStates
 	@defineReserved "switch", get: -> methods.switch
 	@defineReserved "switchInstant", get: -> methods.switchInstant
 	@defineReserved "next", get: -> methods.next
-	@defineReserved "last", get: -> methods.last
 	@defineReserved "state", get: methods.state
 	@defineReserved "on", get: -> methods.on
 	@defineReserved "animationOptions",

--- a/test/tests/LayerStatesBackwardsTest.coffee
+++ b/test/tests/LayerStatesBackwardsTest.coffee
@@ -132,7 +132,7 @@ describe "LayerStates Backwards compatibility", ->
 			test = (previous, current, states) =>
 				previous.should.equal "default"
 				current.should.equal "a"
-				@layer.states.state.should.equal "default"
+				@layer.states.current.name.should.equal "default"
 				done()
 
 			@layer.states.on Events.StateWillSwitch, test
@@ -143,7 +143,7 @@ describe "LayerStates Backwards compatibility", ->
 			test = (previous, current, states) =>
 				previous.should.equal "default"
 				current.should.equal "a"
-				@layer.states.state.should.equal "a"
+				@layer.states.current.name.should.equal "a"
 				done()
 
 			@layer.states.on Events.StateDidSwitch, test

--- a/test/tests/LayerStatesBackwardsTest.coffee
+++ b/test/tests/LayerStatesBackwardsTest.coffee
@@ -61,15 +61,6 @@ describe "LayerStates Backwards compatibility", ->
 			stateB: scale: 0.5
 		assert.deepEqual layer.states.states, [initialStateName, "stateA", "stateB"]
 
-	it "should still support layer.states.animatingKeys", ->
-		layer = new Layer
-		layer.states =
-			stateA: x: 200, y: 300
-			stateB: scale: 0.5
-		assert.deepEqual layer.states.animatingKeys().sort(), ["width", "height", "visible", "opacity", "clip", "scrollHorizontal", "scrollVertical", "x", "y", "z", "scaleX", "scaleY", "scaleZ", "scale", "skewX", "skewY", "skew", "originX", "originY", "originZ", "perspective", "perspectiveOriginX", "perspectiveOriginY", "rotationX", "rotationY", "rotationZ", "rotation", "blur", "brightness", "saturate", "hueRotate", "contrast", "invert", "grayscale", "sepia", "shadowX", "shadowY", "shadowBlur", "shadowSpread", "shadowColor", "backgroundColor", "color", "borderColor", "borderWidth", "force2d", "flat", "backfaceVisible", "borderRadius", "html", "image", "scrollX", "scrollY", "mouseWheelSpeedMultiplier", "velocityThreshold", "constrained"].sort()
-		# delete layer.states[initialStateName]
-		# assert.deepEqual layer.states.animatingKeys().sort(), ["x", "y", "scale"].sort()
-
 	it "should still support layer.states.next", (done) ->
 		layer = new Layer
 		layer.states =

--- a/test/tests/LayerStatesBackwardsTest.coffee
+++ b/test/tests/LayerStatesBackwardsTest.coffee
@@ -83,19 +83,6 @@ describe "LayerStates Backwards compatibility", ->
 			layer.states.next ["stateB", "stateA"]
 		layer.states.next ["stateB", "stateA"]
 
-	it "should still support layer.states.last", (done) ->
-		layer = new Layer
-		layer.states =
-			stateA: x: 200
-			stateB: scale: 0.5
-		layer.stateSwitch "stateB"
-		layer.stateSwitch "stateA"
-		layer.stateSwitch "stateB"
-		layer.onStateDidSwitch ->
-			assert.equal layer.states.current.name, "stateA"
-			done()
-		layer.states.last()
-
 	it "should still support layer.states.animationOptions", ->
 		layer = new Layer
 		layer.states =

--- a/test/tests/LayerStatesBackwardsTest.coffee
+++ b/test/tests/LayerStatesBackwardsTest.coffee
@@ -135,7 +135,7 @@ describe "LayerStates Backwards compatibility", ->
 				@layer.states.current.name.should.equal "default"
 				done()
 
-			@layer.states.on Events.StateWillSwitch, test
+			@layer.on Events.StateWillSwitch, test
 			@layer.states.switchInstant "a"
 
 		it "should emit didSwitch when switching", (done) ->
@@ -146,7 +146,7 @@ describe "LayerStates Backwards compatibility", ->
 				@layer.states.current.name.should.equal "a"
 				done()
 
-			@layer.states.on Events.StateDidSwitch, test
+			@layer.on Events.StateDidSwitch, test
 			@layer.states.switchInstant "a"
 
 

--- a/test/tests/LayerStatesBackwardsTest.coffee
+++ b/test/tests/LayerStatesBackwardsTest.coffee
@@ -10,14 +10,14 @@ describe "LayerStates Backwards compatibility", ->
 			layer.states.add
 				stateA: x: 200
 				stateB: scale: 0.5
-			assert.deepEqual layer.states.stateNames, [initialStateName, "stateA", "stateB"]
+			assert.deepEqual layer.stateNames, [initialStateName, "stateA", "stateB"]
 			assert.deepEqual layer.states.stateA, x: 200
 			assert.deepEqual layer.states.stateB, scale: 0.5
 
 	it "should still support layer.states.add single", ->
 			layer = new Layer
 			layer.states.add("stateA", x: 200)
-			assert.deepEqual layer.states.stateNames, [initialStateName, "stateA"]
+			assert.deepEqual layer.stateNames, [initialStateName, "stateA"]
 			assert.deepEqual layer.states.stateA, x: 200
 
 	it "should still support layer.states.remove", ->
@@ -25,9 +25,9 @@ describe "LayerStates Backwards compatibility", ->
 		layer.states =
 			stateA: x: 200
 			stateB: scale: 0.5
-		assert.deepEqual layer.states.stateNames, [initialStateName, "stateA", "stateB"]
+		assert.deepEqual layer.stateNames, [initialStateName, "stateA", "stateB"]
 		layer.states.remove "stateA"
-		assert.deepEqual layer.states.stateNames, [initialStateName, "stateB"]
+		assert.deepEqual layer.stateNames, [initialStateName, "stateB"]
 
 	it "should still support layer.states.switch", (done) ->
 		layer = new Layer
@@ -46,20 +46,6 @@ describe "LayerStates Backwards compatibility", ->
 			stateB: scale: 0.5
 		layer.states.switchInstant "stateB"
 		assert.equal layer.states.current.name, "stateB"
-
-	it "should still support layer.states.all", ->
-		layer = new Layer
-		layer.states =
-			stateA: x: 200
-			stateB: scale: 0.5
-		assert.deepEqual layer.states.all, [initialStateName, "stateA", "stateB"]
-
-	it "should still support layer.states.states", ->
-		layer = new Layer
-		layer.states =
-			stateA: x: 200
-			stateB: scale: 0.5
-		assert.deepEqual layer.states.states, [initialStateName, "stateA", "stateB"]
 
 	it "should still support layer.states.next", (done) ->
 		layer = new Layer

--- a/test/tests/LayerStatesTest.coffee
+++ b/test/tests/LayerStatesTest.coffee
@@ -215,7 +215,7 @@ describe "LayerStates", ->
 				done()
 			animation = layer.animate "stateA", time: 0.05
 
-	it.skip "should change the state name when using 'previous' as stateName", (done) ->
+	it "should change the state name when using 'previous' as stateName", (done) ->
 		layer = new Layer
 		layer.states =
 			stateA: x: 200
@@ -226,7 +226,6 @@ describe "LayerStates", ->
 		layer.onStateDidSwitch ->
 			assert.equal layer.states.current.name, "stateA"
 			done()
-		console.log layer.states.machine._previousNames, layer.states.previous.name
 		layer.animate "previous"
 
 	describe "Properties", ->

--- a/test/tests/LayerStatesTest.coffee
+++ b/test/tests/LayerStatesTest.coffee
@@ -215,6 +215,20 @@ describe "LayerStates", ->
 				done()
 			animation = layer.animate "stateA", time: 0.05
 
+	it.skip "should change the state name when using 'previous' as stateName", (done) ->
+		layer = new Layer
+		layer.states =
+			stateA: x: 200
+			stateB: scale: 0.5
+		layer.stateSwitch "stateB"
+		layer.stateSwitch "stateA"
+		layer.stateSwitch "stateB"
+		layer.onStateDidSwitch ->
+			assert.equal layer.states.current.name, "stateA"
+			done()
+		console.log layer.states.machine._previousNames, layer.states.previous.name
+		layer.animate "previous"
+
 	describe "Properties", ->
 
 		it "should bring back the 'initial' state values when using 'stateCycle'", (done) ->


### PR DESCRIPTION
This removes the undocumented features of the old API, so they don't clutter the state name space anymore. When people are confused by this, we can now point them to the upgrade guide: https://github.com/koenbok/Framer/wiki/States-and-Animations-upgrade-guide#undocumented-features