### PR TITLE
LayerDraggable reset @_isMoving

### DIFF
--- a/framer/Components/ScrollComponent.coffee
+++ b/framer/Components/ScrollComponent.coffee
@@ -61,6 +61,7 @@ class exports.ScrollComponent extends Layer
 	@define "speedY", @proxyProperty("content.draggable.speedY")
 	@define "isDragging", @proxyProperty("content.draggable.isDragging", {importable: false, exportable: false})
 	@define "isMoving", @proxyProperty("content.draggable.isMoving", {importable: false, exportable: false})
+	@define "isAnimating", @proxyProperty("content.draggable.isAnimating", {importable: false, exportable: false})
 	@define "propagateEvents", @proxyProperty("content.draggable.propagateEvents")
 	@define "directionLock", @proxyProperty("content.draggable.directionLock")
 	@define "directionLockThreshold", @proxyProperty("content.draggable.directionLockThreshold")

--- a/framer/LayerDraggable.coffee
+++ b/framer/LayerDraggable.coffee
@@ -140,7 +140,7 @@ class exports.LayerDraggable extends BaseClass
 
 		# Only reset isMoving if this was not animating when we were clicking
 		# so we can use it to detect a click versus a drag.
-		@_isMoving = @isAnimating
+		@_isMoving = @_isAnimating
 
 		# Stop any animations influencing the position, but no others.
 		for animation in @layer.animations()
@@ -278,6 +278,9 @@ class exports.LayerDraggable extends BaseClass
 		# (which would return a stale value before the simulation had finished one tick)
 		# and because @_start currently calls calculateVelocity().
 		@_isDragging = false
+
+		# reset isMoving if not animating, otherwise animation start/stop will reset it
+		@_isMoving = @_isAnimating
 		@_ignoreUpdateLayerPosition = true
 		@_lastEvent = null
 		@_eventBuffer.reset()
@@ -569,12 +572,14 @@ class exports.LayerDraggable extends BaseClass
 		@emit(Events.DragAnimationStart)
 
 	_stopSimulation: =>
+		@emit(Events.Move, @layer.point) if @_isMoving
 		@_isAnimating = false
+		@_isMoving = false
+
 		return unless @_simulation
 		@_simulation?.x.stop()
 		@_simulation?.y.stop()
 		@_simulation = null
-		@emit(Events.Move, @layer.point)
 		@emit(Events.DragAnimationEnd)
 
 	animateStop: ->

--- a/test/tests/ScrollComponentTest.coffee
+++ b/test/tests/ScrollComponentTest.coffee
@@ -1,3 +1,4 @@
+assert = require "assert"
 
 describe "ScrollComponent", ->
 
@@ -93,12 +94,24 @@ describe "ScrollComponent", ->
 					height: 400
 					parent: scroll.content
 
+				# also check isMoving, isDragging, isAnimating throughout this test
+				# TODO should be separate, when we can actually trick time
+				assert !scroll.isMoving, "must not be moving at start"
+
 				# collect the move events as they happen
 				moves = []
-				scroll.on Events.Move, (event) -> moves.push scroll.direction
+				scroll.on Events.Move, (event) ->
+					#console.log "MOVE", scroll.isMoving, scroll.direction
+					assert scroll.isMoving, "move must be moving"
+					assert scroll.isDragging or scroll.isAnimating, "move must have reason"
+					moves.push scroll.direction
 
 				# verify the timeline of move events looks good
 				draggable.on Events.DragAnimationEnd, (event) ->
+					#console.log "END", scroll.isMoving, scroll.direction
+					assert !scroll.isMoving, "no more moving"
+					assert !scroll.isAnimating, "no more animating"
+					assert !scroll.isDragging, "no more dragging"
 					ups = _.lastIndexOf(moves, "up")
 					downs = moves.indexOf("down")
 					nulls = moves.indexOf(null)


### PR DESCRIPTION
Add to scroll timeline test
Hook up ScrollComponent.isAnimating to content.draggable.isAnimating
Do not emit a move event when animation is stopping, we are not actually moving