### PR TITLE
AnimationBreak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ _projects
 .idea
 Icon
 /extras/resources.framerjs.com/static/DeviceResources/.*
+/yarn.lock

--- a/extras/Studio.framer/app.coffee
+++ b/extras/Studio.framer/app.coffee
@@ -1,0 +1,10 @@
+layer = new Layer
+animation = new Animation layer, {y: 500},
+	onStart: -> print "start"
+	onBreak: -> print "break"
+	onEnd: -> print "end"
+	onStop: -> print "stop"
+	
+animation.start()
+
+Utils.delay 0.3, -> animation.stop()

--- a/extras/Studio.framer/app.coffee
+++ b/extras/Studio.framer/app.coffee
@@ -1,7 +1,7 @@
 layer = new Layer
 animation = new Animation layer, {y: 500},
 	onStart: -> print "start"
-	onBreak: -> print "break"
+	onHalt: -> print "halt"
 	onEnd: -> print "end"
 	onStop: -> print "stop"
 	

--- a/extras/Studio.framer/framer/config.json
+++ b/extras/Studio.framer/framer/config.json
@@ -5,13 +5,12 @@
   "deviceOrientation" : 0,
   "sharedPrototype" : 1,
   "contentScale" : 1,
-  "deviceType" : "apple-macbook",
+  "deviceType" : "fullscreen",
   "selectedHand" : "",
   "updateDelay" : 0.3,
-  "deviceScale" : "fit",
+  "deviceScale" : 1,
   "foldedCodeRanges" : [
 
   ],
-  "orientation" : 0,
-  "fullScreen" : false
+  "orientation" : 0
 }

--- a/framer/Animation.coffee
+++ b/framer/Animation.coffee
@@ -154,6 +154,7 @@ class exports.Animation extends BaseClass
 
 		# Add the callbacks
 		@on(Events.AnimationStart, @options.onStart) if _.isFunction(@options.onStart)
+		@on(Events.AnimationBreak, @options.onBreak) if _.isFunction(@options.onBreak)
 		@on(Events.AnimationStop, @options.onStop) if _.isFunction(@options.onStop)
 		@on(Events.AnimationEnd, @options.onEnd) if _.isFunction(@options.onEnd)
 
@@ -192,7 +193,7 @@ class exports.Animation extends BaseClass
 			@_delayTimer = null
 
 		@layer.context.removeAnimation(@)
-
+		@emit(Events.AnimationBreak) if emit
 		@emit(Events.AnimationStop) if emit
 		Framer.Loop.off("update", @_update)
 

--- a/framer/Animation.coffee
+++ b/framer/Animation.coffee
@@ -154,7 +154,7 @@ class exports.Animation extends BaseClass
 
 		# Add the callbacks
 		@on(Events.AnimationStart, @options.onStart) if _.isFunction(@options.onStart)
-		@on(Events.AnimationBreak, @options.onBreak) if _.isFunction(@options.onBreak)
+		@on(Events.AnimationHalt, @options.onHalt) if _.isFunction(@options.onHalt)
 		@on(Events.AnimationStop, @options.onStop) if _.isFunction(@options.onStop)
 		@on(Events.AnimationEnd, @options.onEnd) if _.isFunction(@options.onEnd)
 
@@ -193,7 +193,7 @@ class exports.Animation extends BaseClass
 			@_delayTimer = null
 
 		@layer.context.removeAnimation(@)
-		@emit(Events.AnimationBreak) if emit
+		@emit(Events.AnimationHalt) if emit
 		@emit(Events.AnimationStop) if emit
 		Framer.Loop.off("update", @_update)
 

--- a/framer/Events.coffee
+++ b/framer/Events.coffee
@@ -36,7 +36,7 @@ Events.Click = Events.TouchEnd
 
 # Animation events
 Events.AnimationStart = "start"
-Events.AnimationBreak = "break"
+Events.AnimationHalt = "halt"
 Events.AnimationStop = "stop"
 Events.AnimationEnd = "end"
 

--- a/framer/Events.coffee
+++ b/framer/Events.coffee
@@ -36,6 +36,7 @@ Events.Click = Events.TouchEnd
 
 # Animation events
 Events.AnimationStart = "start"
+Events.AnimationBreak = "break"
 Events.AnimationStop = "stop"
 Events.AnimationEnd = "end"
 

--- a/test/tests/LayerAnimationTest.coffee
+++ b/test/tests/LayerAnimationTest.coffee
@@ -698,6 +698,16 @@ describe "LayerAnimation", ->
 							layer.x.should.eql 0
 							done()
 
+			it "should call break", (done) ->
+				layer = new Layer
+				layer.animate
+					x: 100
+					options:
+						time: 0.1
+						onBreak: ->
+							done()
+				layer.animateStop()
+
 			it "should call stop", (done) ->
 				layer = new Layer
 				layer.animate

--- a/test/tests/LayerAnimationTest.coffee
+++ b/test/tests/LayerAnimationTest.coffee
@@ -693,18 +693,18 @@ describe "LayerAnimation", ->
 				layer.animate
 					x: 100
 					options:
-						time: 0.1
+						time: AnimationTime
 						onStart: ->
 							layer.x.should.eql 0
 							done()
 
-			it "should call break", (done) ->
+			it "should call halt", (done) ->
 				layer = new Layer
 				layer.animate
 					x: 100
 					options:
-						time: 0.1
-						onBreak: ->
+						time: AnimationTime
+						onHalt: ->
 							done()
 				layer.animateStop()
 
@@ -713,7 +713,7 @@ describe "LayerAnimation", ->
 				layer.animate
 					x: 100
 					options:
-						time: 0.1
+						time: AnimationTime
 						onStop: ->
 							layer.x.should.eql 100
 							done()
@@ -723,7 +723,7 @@ describe "LayerAnimation", ->
 				layer.animate
 					x: 100
 					options:
-						time: 0.1
+						time: AnimationTime
 						onEnd: ->
 							layer.x.should.eql 100
 							done()


### PR DESCRIPTION
Proposal to add a new animation event. Currently we have:

- `AnimationStart` the animation started.
- `AnimationStop` the animation stopped at any point (always thrown).
- `AnimationEnd` the animation stopped and fully completed.

What we are missing is an event that emits when an animation is stopped mid-way (so stopped, but not ended). I propose to add `AnimationBreak`.