### PR TITLE
Fix passing any shape as parameter to SVGLayer

### DIFF
--- a/framer/SVGLayer.coffee
+++ b/framer/SVGLayer.coffee
@@ -15,6 +15,6 @@ class exports.SVGLayer extends Layer
 		@svg.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xlink", "http://www.w3.org/1999/xlink")
 
 	addShape: (type) ->
-		shape = document.createElementNS("http://www.w3.org/2000/svg", "circle")
+		shape = document.createElementNS("http://www.w3.org/2000/svg", type)
 		@svg.appendChild(shape)
 		return shape


### PR DESCRIPTION
Considering `type` was passed but not used, I suppose this was the intention.