### PR TITLE
fix new Layer({scroll:true}), ignoreEvents default was in the way

### DIFF
--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -224,6 +224,9 @@ class exports.Layer extends BaseClass
 	# Default animation options for every animation of this layer
 	@define "animationOptions", @simpleProperty("animationOptions", {})
 
+	# Behaviour properties
+	@define "ignoreEvents", layerProperty(@, "ignoreEvents", "pointerEvents", true, _.isBoolean)
+
 	# Css properties
 	@define "width",  layerProperty(@, "width", "width", 100, _.isNumber, null, {}, (layer, value) ->
 		return if not layer.constraintValues? or layer.isLayouting
@@ -255,9 +258,6 @@ class exports.Layer extends BaseClass
 	@define "scroll",
 		get: -> @scrollHorizontal is true or @scrollVertical is true
 		set: (value) -> @scrollHorizontal = @scrollVertical = value
-
-	# Behaviour properties
-	@define "ignoreEvents", layerProperty(@, "ignoreEvents", "pointerEvents", true, _.isBoolean)
 
 	# Matrix properties
 	@define "x", layerProperty(@, "x", "webkitTransform", 0, _.isNumber,

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -436,6 +436,11 @@ describe "Layer", ->
 			layer.style["overflow"].should.equal "scroll"
 			layer.ignoreEvents.should.equal false
 
+		it "should disable ignore events when scroll is set from constructor", ->
+			layerA = new Layer
+				scroll: true
+			layerA.ignoreEvents.should.equal false
+
 		it "should set style properties on create", ->
 
 			layer = new Layer backgroundColor: "red"


### PR DESCRIPTION
move @define ignoreEvents property before any scroll properties
fixes motif/company#795

```
layerB = new Layer
	clip: true	
	height: 100
	width: 200
	y: 300	
	scroll: true

for i in [0..20]
	new Layer
		parent: layerB
		height: 20
		y: i * 20
		backgroundColor: Utils.randomColor()
```

this did not work, unless you add `layerB.scroll = true`