### PR TITLE
when using mouse wheel, the scroll.direction was bogus

### DIFF
--- a/framer/Components/ScrollComponent.coffee
+++ b/framer/Components/ScrollComponent.coffee
@@ -401,9 +401,13 @@ class exports.ScrollComponent extends Layer
 
 		@content.point = point
 
+		# make sure _lastEvent is set on our draggable, and that it has a delta.{x,y}
+		event.delta = {x: deltaX, y: deltaY}
+		@content.draggable._lastEvent = event
 		@content.emit(Events.Move, point)
 		@emit(Events.Scroll, event)
 		@_onMouseWheelEnd(event)
+		@content.draggable._lastEvent = null
 
 	# Because there is no real scroll end event on a mousewheel, we use a timeout to see if
 	# events stop coming in, and throw a scroll event after. Better than nothing.

--- a/test/tests/ScrollComponentTest.coffee
+++ b/test/tests/ScrollComponentTest.coffee
@@ -80,10 +80,14 @@ describe "ScrollComponent", ->
 					parent: scroll.content
 				scroll.mouseWheelEnabled = true
 				scroll.on Events.Move, (event) ->
+					if event.y is 0
+						scroll.direction.should.equal "up"
+						return done()
 					event.x.should.equal -75
 					event.y.should.equal -150
-					done()
+					scroll.direction.should.equal "down"
 				scroll.emit(Events.MouseWheel, {wheelDeltaX: -75, wheelDeltaY: -150})
+				scroll.emit(Events.MouseWheel, {wheelDeltaX: 0, wheelDeltaY: 150})
 
 		describe "scrolling with touch events", ->
 			it "should have direction", (done) ->


### PR DESCRIPTION
by temporarily setting _lastEvent to draggable, the direction is correctly
calculated when there is no velicity