### PR TITLE
Feature/layer selector

### DIFF
--- a/framer/Context.coffee
+++ b/framer/Context.coffee
@@ -150,8 +150,11 @@ class exports.Context extends BaseClass
 		return layer if layer
 		return @layerForElement(element.parentNode)
 
-	selectLayers: (selector) ->
-		return _.filter @_layers, (layer) -> Utils.layerMatchesSelector(layer, selector)
+	selectLayer: (selector) ->
+		Utils.findLayer(@_layers, selector)
+
+	selectAllLayers: (selector) ->
+		Utils.filterLayers(@_layers, selector)
 
 	layout: =>
 		@rootLayers.map (l) -> l.layout()

--- a/framer/Context.coffee
+++ b/framer/Context.coffee
@@ -150,6 +150,9 @@ class exports.Context extends BaseClass
 		return layer if layer
 		return @layerForElement(element.parentNode)
 
+	selectLayers: (selector) ->
+		return _.filter @_layers, (layer) -> Utils.layerMatchesSelector(layer, selector)
+
 	layout: =>
 		@rootLayers.map (l) -> l.layout()
 

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -1069,7 +1069,20 @@ class exports.Layer extends BaseClass
 
 	select: (selector) ->
 		layers = _.find @descendants, (layer) ->
-			Utils.layerMatchesSelector(layer,selector)
+			Utils.layerMatchesSelector(layer, selector)
+
+	selectAll: (selector) ->
+		layers = @descendants.filter (layer) ->
+			Utils.layerMatchesSelector(layer, selector)
+
+
+	@select: (selector) ->
+		layers = _.find Framer.CurrentContext.layers, (layer) ->
+			Utils.layerMatchesSelector(layer, selector)
+
+	@selectAll: (selector) ->
+		layers = Framer.CurrentContext.layers.filter (layer) ->
+			Utils.layerMatchesSelector(layer, selector)
 
 	##############################################################
 	# Backwards superLayer and children compatibility

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -823,6 +823,12 @@ class exports.Layer extends BaseClass
 	querySelector: (query) -> @_element.querySelector(query)
 	querySelectorAll: (query) -> @_element.querySelectorAll(query)
 
+	selectChild: (selector) ->
+		Utils.findLayer(@descendants, selector)
+
+	selectAllChildren: (selector) ->
+		Utils.filterLayers(@descendants, selector)
+
 	destroy: ->
 
 		# Todo: check this
@@ -1066,14 +1072,6 @@ class exports.Layer extends BaseClass
 			return @parent
 		if @_context._parent
 			return @_context._parent
-
-	select: (selector) ->
-		layers = _.find @descendants, (layer) ->
-			Utils.layerMatchesSelector(layer, selector)
-
-	selectAll: (selector) ->
-		layers = @descendants.filter (layer) ->
-			Utils.layerMatchesSelector(layer, selector)
 
 
 	@select: (selector) ->

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -1067,6 +1067,10 @@ class exports.Layer extends BaseClass
 		if @_context._parent
 			return @_context._parent
 
+	find: (selector) ->
+		layers = _.find @descendants, (layer) ->
+			Utils.layerMatchesSelector(layer,selector)
+
 	##############################################################
 	# Backwards superLayer and children compatibility
 

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -829,6 +829,12 @@ class exports.Layer extends BaseClass
 	selectAllChildren: (selector) ->
 		Utils.filterLayers(@descendants, selector)
 
+	@select: (selector) ->
+		Framer.CurrentContext.selectLayer(selector)
+
+	@selectAll: (selector) ->
+		Framer.CurrentContext.selectAllLayers(selector)
+
 	destroy: ->
 
 		# Todo: check this
@@ -1072,15 +1078,6 @@ class exports.Layer extends BaseClass
 			return @parent
 		if @_context._parent
 			return @_context._parent
-
-
-	@select: (selector) ->
-		layers = _.find Framer.CurrentContext.layers, (layer) ->
-			Utils.layerMatchesSelector(layer, selector)
-
-	@selectAll: (selector) ->
-		layers = Framer.CurrentContext.layers.filter (layer) ->
-			Utils.layerMatchesSelector(layer, selector)
 
 	##############################################################
 	# Backwards superLayer and children compatibility

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -1067,7 +1067,7 @@ class exports.Layer extends BaseClass
 		if @_context._parent
 			return @_context._parent
 
-	find: (selector) ->
+	select: (selector) ->
 		layers = _.find @descendants, (layer) ->
 			Utils.layerMatchesSelector(layer,selector)
 

--- a/framer/Utils.coffee
+++ b/framer/Utils.coffee
@@ -287,21 +287,21 @@ Utils.uuid = ->
 Utils.layerMatchesSelector = (layer, selector) ->
 	getHierarchyString = (l) ->
 		# create a string of the hierarchy so we can run regex on it
-		nameArr = _.pluck(l.ancestors().reverse(),'name')
+		nameArr = _.pluck(l.ancestors().reverse(), 'name')
 		return nameArr.join('>') + ">#{layer.name}"
-					
+
 	hierarchyMatch = (hierarchy, string) ->
-		string = string.replace(/\s*>\s*/g,'>') # clean spaces around >
+		string = string.replace(/\s*>\s*/g, '>') # clean spaces around >
 		string = string.split('*').join('[^>]*') # anything but >
 		string = string.split(' ').join('(?:.*)>') # anything but ends with >
 		string = string.split(',').join('$|') # or
 		regexString = "(^|>)"+string+"$"
-	
-		regExp = new RegExp(regexString) 
+
+		regExp = new RegExp(regexString)
 		return regExp.test(hierarchy)
-		
+
 	if selector
-		hierarchy = getHierarchyString(layer,selector)
+		hierarchy = getHierarchyString(layer, selector)
 		return hierarchyMatch(hierarchy, selector)
 
 Utils.arrayFromArguments = (args) ->

--- a/framer/Utils.coffee
+++ b/framer/Utils.coffee
@@ -284,6 +284,12 @@ Utils.uuid = ->
 
 	output.join ""
 
+Utils.findLayer = (layers, selector) ->
+	_.find layers, (layer) -> Utils.layerMatchesSelector(layer, selector)
+
+Utils.filterLayers = (layers, selector) ->
+	_.filter layers, (layer) -> Utils.layerMatchesSelector(layer, selector)
+
 Utils.layerMatchesSelector = (layer, selector) ->
 	getHierarchyString = (l) ->
 		# create a string of the hierarchy so we can run regex on it

--- a/framer/Utils.coffee
+++ b/framer/Utils.coffee
@@ -284,6 +284,26 @@ Utils.uuid = ->
 
 	output.join ""
 
+Utils.layerMatchesSelector = (layer, selector) ->
+	getHierarchyString = (l) ->
+		# create a string of the hierarchy so we can run regex on it
+		nameArr = _.pluck(l.ancestors().reverse(),'name')
+		return nameArr.join('>') + ">#{layer.name}"
+					
+	hierarchyMatch = (hierarchy, string) ->
+		string = string.replace(/\s*>\s*/g,'>') # clean spaces around >
+		string = string.split('*').join('[^>]*') # anything but >
+		string = string.split(' ').join('(?:.*)>') # anything but ends with >
+		string = string.split(',').join('$|') # or
+		regexString = "(^|>)"+string+"$"
+	
+		regExp = new RegExp(regexString) 
+		return regExp.test(hierarchy)
+		
+	if selector
+		hierarchy = getHierarchyString(layer,selector)
+		return hierarchyMatch(hierarchy, selector)
+
 Utils.arrayFromArguments = (args) ->
 	# Convert an arguments object to an array
 	return args[0] if _.isArray(args[0])

--- a/test/tests/ContextTest.coffee
+++ b/test/tests/ContextTest.coffee
@@ -205,7 +205,12 @@ describe "Context", ->
 				layerA = new Layer
 				context.layerForElement(layerA._element).should.equal layerA
 
+		it "should implement selectLayer", ->
 
+			context = new Framer.Context(name:"Test")
+			context.run ->
+				layerA = new Layer name: "layerA"
+				context.selectLayers("layerA").should.eql [layerA]
 
 	describe "Events", ->
 

--- a/test/tests/ContextTest.coffee
+++ b/test/tests/ContextTest.coffee
@@ -207,10 +207,17 @@ describe "Context", ->
 
 		it "should implement selectLayer", ->
 
-			context = new Framer.Context(name:"Test")
+			context = new Framer.Context(name: "Test")
 			context.run ->
 				layerA = new Layer name: "layerA"
-				context.selectLayers("layerA").should.eql [layerA]
+				context.selectLayer("layerA").should.eql layerA
+
+		it "should implement selectAllLayers", ->
+
+			context = new Framer.Context(name: "Test")
+			context.run ->
+				layerA = new Layer name: "layerA"
+				context.selectAllLayers("layerA").should.eql [layerA]
 
 	describe "Events", ->
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -900,12 +900,12 @@ describe "Layer", ->
 			layerC = new Layer name: 'C', parent: layerB
 			Layer.select('B > *').should.equal layerC
 
-		it "should have a method `selectAll`", ->
+		it "should have a method `selectAllChildren`", ->
 			layerA = new Layer name: 'A'
 			layerB = new Layer name: 'B', parent: layerA
 			layerC = new Layer name: 'C', parent: layerB
 			layerD = new Layer name: 'D', parent: layerB
-			layerA.selectAll('B > *').should.eql [layerC, layerD]
+			layerA.selectAllChildren('B > *').should.eql [layerC, layerD]
 
 		it "should have a static method `selectAll`", ->
 			layerA = new Layer name: 'A'

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -617,7 +617,7 @@ describe "Layer", ->
 			layer.shadowBlur.should.equal 10
 			layer.shadowSpread.should.equal 10
 
-			layer.style.boxShadow.should.equal "rgba(123, 123, 123, 0.496094) 10px 10px 10px 10px"
+			layer.style.boxShadow.should.equal "rgba(123, 123, 123, 0.498039) 10px 10px 10px 10px"
 
 			# Only after we set a color a shadow should be drawn
 			layer.shadowColor = "red"
@@ -879,6 +879,9 @@ describe "Layer", ->
 			layerC.ancestors().should.eql [layerB, layerA]
 
 	describe "Select", ->
+		beforeEach ->
+			Framer.CurrentContext.reset()
+
 		it "should select the layer named B", ->
 			layerA = new Layer name: 'A'
 			layerB = new Layer name: 'B', parent: layerA
@@ -889,6 +892,26 @@ describe "Layer", ->
 			layerB = new Layer name: 'B', parent: layerA
 			layerC = new Layer name: 'C', parent: layerB
 			layerA.select('B > *').should.equal layerC
+
+		it "should have a static method `select`", ->
+			layerA = new Layer name: 'A'
+			layerB = new Layer name: 'B', parent: layerA
+			layerC = new Layer name: 'C', parent: layerB
+			Layer.select('B > *').should.equal layerC
+
+		it "should have a method `selectAll`", ->
+			layerA = new Layer name: 'A'
+			layerB = new Layer name: 'B', parent: layerA
+			layerC = new Layer name: 'C', parent: layerB
+			layerD = new Layer name: 'D', parent: layerB
+			layerA.selectAll('B > *').should.eql [layerC, layerD]
+
+		it "should have a static method `selectAll`", ->
+			layerA = new Layer name: 'A'
+			layerB = new Layer name: 'B', parent: layerA # asdas
+			layerC = new Layer name: 'C', parent: layerB
+			layerD = new Layer name: 'D', parent: layerB
+			Layer.selectAll('A *').should.eql [layerB, layerC, layerD]
 
 	describe "Frame", ->
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -617,7 +617,7 @@ describe "Layer", ->
 			layer.shadowBlur.should.equal 10
 			layer.shadowSpread.should.equal 10
 
-			layer.style.boxShadow.should.equal "rgba(123, 123, 123, 0.498039) 10px 10px 10px 10px"
+			layer.style.boxShadow.should.equal "rgba(123, 123, 123, 0.496094) 10px 10px 10px 10px"
 
 			# Only after we set a color a shadow should be drawn
 			layer.shadowColor = "red"
@@ -878,17 +878,17 @@ describe "Layer", ->
 			layerC = new Layer superLayer: layerB
 			layerC.ancestors().should.eql [layerB, layerA]
 
-	describe "Find", ->
-		it "should find the layer named B", ->
+	describe "Select", ->
+		it "should select the layer named B", ->
 			layerA = new Layer name: 'A'
 			layerB = new Layer name: 'B', parent: layerA
-			layerA.find('B').should.equal layerB
+			layerA.select('B').should.equal layerB
 
-		it "should find the layer named C", ->
+		it "should select the layer named C", ->
 			layerA = new Layer name: 'A'
 			layerB = new Layer name: 'B', parent: layerA
 			layerC = new Layer name: 'C', parent: layerB
-			layerA.find('B > *').should.equal layerC
+			layerA.select('B > *').should.equal layerC
 
 	describe "Frame", ->
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -878,6 +878,17 @@ describe "Layer", ->
 			layerC = new Layer superLayer: layerB
 			layerC.ancestors().should.eql [layerB, layerA]
 
+	describe "Find", ->
+		it "should find the layer named B", ->
+			layerA = new Layer name: 'A'
+			layerB = new Layer name: 'B', parent: layerA
+			layerA.find('B').should.equal layerB
+
+		it "should find the layer named C", ->
+			layerA = new Layer name: 'A'
+			layerB = new Layer name: 'B', parent: layerA
+			layerC = new Layer name: 'C', parent: layerB
+			layerA.find('B > *').should.equal layerC
 
 	describe "Frame", ->
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -878,20 +878,21 @@ describe "Layer", ->
 			layerC = new Layer superLayer: layerB
 			layerC.ancestors().should.eql [layerB, layerA]
 
-	describe "Select", ->
+	describe "Select Layer", ->
+
 		beforeEach ->
 			Framer.CurrentContext.reset()
 
 		it "should select the layer named B", ->
 			layerA = new Layer name: 'A'
 			layerB = new Layer name: 'B', parent: layerA
-			layerA.select('B').should.equal layerB
+			layerA.selectChild('B').should.equal layerB
 
 		it "should select the layer named C", ->
 			layerA = new Layer name: 'A'
 			layerB = new Layer name: 'B', parent: layerA
 			layerC = new Layer name: 'C', parent: layerB
-			layerA.select('B > *').should.equal layerC
+			layerA.selectChild('B > *').should.equal layerC
 
 		it "should have a static method `select`", ->
 			layerA = new Layer name: 'A'

--- a/test/tests/UtilsTest.coffee
+++ b/test/tests/UtilsTest.coffee
@@ -193,6 +193,43 @@ describe "Utils", ->
 	# 		test = -> Utils.domLoadDataSync("static/nonexisting.txt")
 	# 		test.should.throw()
 
+	describe "layerMatchesSelector", ->
+		it "should match exact", ->
+			layerA = new Layer name: "layerA"
+			Utils.layerMatchesSelector(layerA,'layerA').should.equal true
+
+		it "should match anything below", ->
+			layerA = new Layer name: "layerA"
+			layerB = new Layer name: "layerB", parent: layerA
+			layerC = new Layer name: "layerC", parent: layerB
+			Utils.layerMatchesSelector(layerB,'layerA > *').should.equal true
+
+		it "should match descendant with wildcard", ->
+			layerA = new Layer name: "layerA"
+			layerB = new Layer name: "layerB", parent: layerA
+			layerC = new Layer name: "layerC", parent: layerB
+			Utils.layerMatchesSelector(layerC,'layerA layer*').should.equal true
+
+		it "should match containing", ->
+			layerA = new Layer name: "layerA1"
+			layerB = new Layer name: "layerB1", parent: layerA
+			layerC = new Layer name: "layerC1", parent: layerB
+			Utils.layerMatchesSelector(layerB,'*rB*').should.equal true
+
+		it "should match multiple direct children", ->
+			layerA = new Layer name: "layerA"
+			layerB = new Layer name: "layerB", parent: layerA
+			layerC = new Layer name: "layerC", parent: layerB
+			Utils.layerMatchesSelector(layerC,'layerA>layerB>layerC').should.equal true
+
+		it "should match multiple direct children", ->
+			layerA = new Layer name: "layerA"
+			layerB = new Layer name: "layerB", parent: layerA
+			layerC = new Layer name: "layerC", parent: layerB
+			Utils.layerMatchesSelector(layerA,'layerB,layerC').should.equal false
+			Utils.layerMatchesSelector(layerB,'layerB,layerC').should.equal true
+			Utils.layerMatchesSelector(layerC,'layerB,layerC').should.equal true
+
 	describe "modulate", ->
 
 		it "should have the right results", ->

--- a/test/tests/UtilsTest.coffee
+++ b/test/tests/UtilsTest.coffee
@@ -196,39 +196,39 @@ describe "Utils", ->
 	describe "layerMatchesSelector", ->
 		it "should match exact", ->
 			layerA = new Layer name: "layerA"
-			Utils.layerMatchesSelector(layerA,'layerA').should.equal true
+			Utils.layerMatchesSelector(layerA, 'layerA').should.equal true
 
 		it "should match anything below", ->
 			layerA = new Layer name: "layerA"
 			layerB = new Layer name: "layerB", parent: layerA
 			layerC = new Layer name: "layerC", parent: layerB
-			Utils.layerMatchesSelector(layerB,'layerA > *').should.equal true
+			Utils.layerMatchesSelector(layerB, 'layerA > *').should.equal true
 
 		it "should match descendant with wildcard", ->
 			layerA = new Layer name: "layerA"
 			layerB = new Layer name: "layerB", parent: layerA
 			layerC = new Layer name: "layerC", parent: layerB
-			Utils.layerMatchesSelector(layerC,'layerA layer*').should.equal true
+			Utils.layerMatchesSelector(layerC, 'layerA layer*').should.equal true
 
 		it "should match containing", ->
 			layerA = new Layer name: "layerA1"
 			layerB = new Layer name: "layerB1", parent: layerA
 			layerC = new Layer name: "layerC1", parent: layerB
-			Utils.layerMatchesSelector(layerB,'*rB*').should.equal true
+			Utils.layerMatchesSelector(layerB, '*rB*').should.equal true
 
 		it "should match multiple direct children", ->
 			layerA = new Layer name: "layerA"
 			layerB = new Layer name: "layerB", parent: layerA
 			layerC = new Layer name: "layerC", parent: layerB
-			Utils.layerMatchesSelector(layerC,'layerA>layerB>layerC').should.equal true
+			Utils.layerMatchesSelector(layerC, 'layerA>layerB>layerC').should.equal true
 
 		it "should match multiple direct children", ->
 			layerA = new Layer name: "layerA"
 			layerB = new Layer name: "layerB", parent: layerA
 			layerC = new Layer name: "layerC", parent: layerB
-			Utils.layerMatchesSelector(layerA,'layerB,layerC').should.equal false
-			Utils.layerMatchesSelector(layerB,'layerB,layerC').should.equal true
-			Utils.layerMatchesSelector(layerC,'layerB,layerC').should.equal true
+			Utils.layerMatchesSelector(layerA, 'layerB,layerC').should.equal false
+			Utils.layerMatchesSelector(layerB, 'layerB,layerC').should.equal true
+			Utils.layerMatchesSelector(layerC, 'layerB,layerC').should.equal true
 
 	describe "modulate", ->
 


### PR DESCRIPTION
This is building upon #336 and #436, changing:
- The names of some of the methods
- The implementation of the methods to be more defined in terms of each other

It still has supports these selectors:

| Selector | Result |
| --- | --- |
| A | Any layer named A |
| A B | Any layer named B that is a descendant of a layer named A (that is: a child, or a child of a child, etc.) |
| A > B | Any layer named B that is a child (i.e. direct child) of a layer named A |
| A, B | Any layer named A or any layer named B |
| * | Any layer (wildcard character) |

And adds a couple of API's:
```coffee
layer = new Layer

# Selects layer(s) that are decendants of this layer
layer.selectChild("A")
layer.selectAllChildren("A*")

context = new Framer.Context(name: "Test")
# Selects layer(s) in a specific context
context.selectLayer("A")
context.selectAllLayers( "A*")

# Selects layer(s) in the current context
Layer.select("A") 
Layer.selectAll("A*")

```