### PR TITLE
add reset methods to TouchEmulator and GestureInputRecognizer

### DIFF
--- a/framer/Extras/TouchEmulator.coffee
+++ b/framer/Extras/TouchEmulator.coffee
@@ -232,3 +232,10 @@ exports.disable = ->
 	touchEmulator.destroy()
 	touchEmulator = null
 	Events.enableEmulatedTouchEvents(false)
+
+# resets the emulator, useful if the webview can loose/regain focus without being aware
+# in such scenarios it can miss mouseup, mouseout events and such
+# it can also be fixed by checking event.buttons in mousemove, but that is not available on safari
+exports.reset = ->
+	return unless touchEmulator
+	touchEmulator.endMultiTouch()

--- a/framer/GestureInputRecognizer.coffee
+++ b/framer/GestureInputRecognizer.coffee
@@ -18,6 +18,7 @@ class exports.GestureInputRecognizer
 		@em = new DOMEventManager()
 		@em.wrap(window).addEventListener("mousedown", @startMouse)
 		@em.wrap(window).addEventListener("touchstart", @startTouch)
+		@session = null
 
 	destroy: ->
 		@em.removeAllListeners()
@@ -84,8 +85,7 @@ class exports.GestureInputRecognizer
 		@em.wrap(window).removeEventListener("mouseup", @touchend)
 		@em.wrap(window).removeEventListener("touchmove", @touchmove)
 		@em.wrap(window).removeEventListener("touchend", @touchend)
-
-		@em.wrap(window).addEventListener("webkitmouseforcechanged", @_updateMacForce)
+		@em.wrap(window).removeEventListener("webkitmouseforcechanged", @_updateMacForce)
 
 		event = @_getGestureEvent(event)
 
@@ -102,6 +102,10 @@ class exports.GestureInputRecognizer
 
 		@tapend(event)
 		@cancel()
+
+	reset: =>
+		return unless @session
+		@touchend(@session.lastEvent)
 
 	# Tap
 


### PR DESCRIPTION
can be used for webviews that mght miss mouseout/mouseup events because
they are hidden or disabled from the outside