### PR TITLE
Fix/slider broken anims

### DIFF
--- a/framer/AnimationLoop.coffee
+++ b/framer/AnimationLoop.coffee
@@ -56,12 +56,12 @@ class exports.AnimationLoop extends EventEmitter
 		tick = (timestamp) ->
 
 			if animationLoop.raf
-				update()
 				window.requestAnimationFrame(tick)
+				update()
 			else
 				window.setTimeout ->
-					update()
 					window.requestAnimationFrame(tick)
+					update()
 				, 0
 
 		tick()

--- a/framer/Components/SliderComponent.coffee
+++ b/framer/Components/SliderComponent.coffee
@@ -184,15 +184,16 @@ class exports.SliderComponent extends Layer
 
 	@define "min",
 		get: -> @_min or 0
-		set: (value) -> @_min = value
+		set: (value) -> @_min = value if _.isFinite(value)
 
 	@define "max",
 		get: -> @_max or 1
-		set: (value) -> @_max = value
+		set: (value) -> @_max = value if _.isFinite(value)
 
 	@define "value",
 		get: -> return @_value
 		set: (value) ->
+			return unless _.isFinite(value)
 
 			@_value = Utils.clamp(value, @min, @max)
 
@@ -244,6 +245,7 @@ class exports.SliderComponent extends Layer
 				return Utils.modulate(value, [0, @height], [@min, @max], true)
 
 	animateToValue: (value, animationOptions={curve: "spring(300, 25, 0)"}) ->
+		return unless _.isFinite(value)
 		if @width > @height
 			animationOptions.properties = {x: @pointForValue(value) - (@knob.width/2)}
 		else


### PR DESCRIPTION
If animations result in errors during update, animation loop will stop ticking, forever. Even after a context reset. Fix that by first requesting a next frame, then doing logic.

Such broken animations could be triggered by calling SliderComponent.animateToValue(); so adding guards against weird slider values. (There is can be a loop in between knop position change -> update value -> change knob position, normally broken by value == lastvalue, but !(NaN == NaN))