### PR TITLE
Utils.modulate can use an array to clamp

### DIFF
--- a/framer/Utils.coffee
+++ b/framer/Utils.coffee
@@ -475,6 +475,7 @@ Utils.mapRange = (value, fromLow, fromHigh, toLow, toHigh) ->
 	toLow + (((value - fromLow) / (fromHigh - fromLow)) * (toHigh - toLow))
 
 # Kind of similar as above but with a better syntax and a limiting option
+# Improve limiting option by adding array support for different settings on low and high range
 Utils.modulate = (value, rangeA, rangeB, limit=false) ->
 
 	[fromLow, fromHigh] = rangeA
@@ -488,15 +489,27 @@ Utils.modulate = (value, rangeA, rangeB, limit=false) ->
 
 	result = toLow + (((value - fromLow) / (fromHigh - fromLow)) * (toHigh - toLow))
 
-	if limit is true
+	if limit is true or _.isEqual(limit, [true, true])
 		if toLow < toHigh
 			return toLow if result < toLow
 			return toHigh if result > toHigh
 		else
 			return toLow if result > toLow
 			return toHigh if result < toHigh
+	
+	if _.isEqual(limit, [true, false])
+		if toLow < toHigh
+			return toLow if result < toLow
+		else
+			return toLow if result > toLow
 
-	result
+	if _.isEqual(limit, [false, true])
+		if toLow < toHigh
+			return toHigh if result > toHigh
+		else
+			return toHigh if result < toHigh
+
+	return result
 
 
 

--- a/test/tests/UtilsTest.coffee
+++ b/test/tests/UtilsTest.coffee
@@ -207,6 +207,26 @@ describe "Utils", ->
 			Utils.modulate(0, [1, 2], [100, 0], true).should.equal 100
 			Utils.modulate(0, [1, 2], [100, 0], false).should.equal 200
 
+			# Array support
+			Utils.modulate(0.5, [0, 1], [0, 100], [true, true]).should.equal 50
+			Utils.modulate(1, [0, 1], [0, 100], [true, true]).should.equal 100
+
+			Utils.modulate(2, [0, 1], [0, 100], [true, true]).should.equal 100
+			Utils.modulate(0, [1, 2], [0, 100], [true, true]).should.equal 0
+			Utils.modulate(0, [1, 2], [100, 0], [true, true]).should.equal 100
+
+			Utils.modulate(2, [0, 1], [0, 100], [false, false]).should.equal 200
+			Utils.modulate(0, [1, 2], [0, 100], [false, false]).should.equal -100
+			Utils.modulate(0, [1, 2], [100, 0], [false, false]).should.equal 200
+
+			Utils.modulate(2, [0, 1], [0, 100], [true, false]).should.equal 200
+			Utils.modulate(0, [1, 2], [0, 100], [true, false]).should.equal 0
+			Utils.modulate(0, [1, 2], [100, 0], [true, false]).should.equal 100
+
+			Utils.modulate(2, [0, 1], [0, 100], [false, true]).should.equal 100
+			Utils.modulate(0, [1, 2], [0, 100], [false, true]).should.equal -100
+			Utils.modulate(0, [1, 2], [100, 0], [false, true]).should.equal 200
+
 	describe "clamp", ->
 
 		it "should have the right results", ->


### PR DESCRIPTION
A simple tweak I've been using to create some common UI effect (PTR on a header, expandable header with some kind of overdrag).

Utils.modulate can use boolean or an array of two booleans as limit value.
```
Utils.modulate(value, [fromLow, fromHigh], [toLow, toHigh], [limitLow, limitHigh])
```


Example: https://framer.cloud/OduGh/