### PR TITLE
Small tweaks to fix certain broken Layer image URLs

### DIFF
--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -714,7 +714,8 @@ class exports.Layer extends BaseClass
 			# imageUrl = Config.baseUrl + imageUrl
 
 			if @_alwaysUseImageCache is false and Utils.isLocalAssetUrl(imageUrl)
-				imageUrl += "?nocache=#{NoCacheDateKey}"
+				imageUrl += if /\?/.test(imageUrl) then '&' else '?'
+				imageUrl += "nocache=#{NoCacheDateKey}"
 
 			# As an optimization, we will only use a loader
 			# if something is explicitly listening to the load event

--- a/framer/Utils.coffee
+++ b/framer/Utils.coffee
@@ -369,7 +369,7 @@ Utils.isRelativeUrl = (url) ->
 	not /^([a-zA-Z]{1,8}:\/\/).*$/.test(url)
 
 Utils.isLocalServerUrl = (url) ->
-	return url.indexOf("127.0.0.1") isnt -1 or url.indexOf("localhost")  isnt -1
+	return /[a-zA-Z]{1,8}:\/\/127\.0\.0\.1/.test(url) or /[a-zA-Z]{1,8}:\/\/localhost/.test(url)
 
 Utils.isLocalUrl = (url) ->
 	return true if Utils.isFileUrl(url)

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -276,6 +276,23 @@ describe "Layer", ->
 			layer.style["background-image"].indexOf("data:").should.not.equal(-1)
 			layer.style["background-image"].indexOf("?nocache=").should.equal(-1)
 
+		
+		it "should append nocache with an ampersand if url params already exist", (done) ->
+			
+			prefix = "../"
+			imagePath = "static/test.png?param=foo"
+			fullPath = prefix + imagePath
+			layer = new Layer
+
+			layer.on Events.ImageLoaded, ->
+				layer.style["background-image"].indexOf(imagePath).should.not.equal(-1)
+				layer.style["background-image"].indexOf("file://").should.not.equal(-1)
+				layer.style["background-image"].indexOf("&nocache=").should.not.equal(-1)
+				done()
+
+			layer.image = fullPath
+			layer.image.should.equal fullPath
+
 
 		it "should cancel loading when setting image to null", (done) ->
 			prefix = "../"

--- a/test/tests/UtilsTest.coffee
+++ b/test/tests/UtilsTest.coffee
@@ -430,6 +430,7 @@ describe "Utils", ->
 			Utils.isLocalServerUrl("https://127.0.0.1/index.html").should.equal(true)
 			Utils.isLocalServerUrl(".././Desktop/index.html").should.equal(false)
 			Utils.isLocalServerUrl("https://apple.com/index.html").should.equal(false)
+			Utils.isLocalServerUrl("https://apple.com/?url=http%3A%2F%2F127.0.0.1").should.equal(false)
 
 	describe "isLocalAssetUrl", ->
 		it "should work", ->


### PR DESCRIPTION
I was working on a prototype that required assigning `Layer` image URLs of the following form:

`https://foo.bar.com/photo/transcode?url=http%3A%2F%2F127.0.0.1%2Fthumb%2F1484295501&width=132&height=200`

... and I was running in to two semi-related issues addressed by this PR.

First, URLs of that form were incorrectly being identified as local because they contain the string `127.0.0.1` even though it's buried deep in the query string. 	3b6c061 addresses this by applying stricter matching (while copying the still-somewhat-imprecise scheme matching `[a-zA-Z]{1,8}:\/\/` from the method above).

Second, when the `Layer` evaluates whether to include the `nocache` param, it doesn't take into account whether a querystring is already present, and just appends `?nocache=` in all cases, leading to a malformed request for the (incorrectly identified-as-local) URL form above. f9c6611 addresses this by looking for a `?` and appending with `&` instead if present.

I realize this is probably a niche case, but I believe each of these is low-risk and more correct in its own right, so hopefully worth consideration. Thanks!