### PR TITLE
Prevent rounding bug in LayerDraggable

### DIFF
--- a/framer/LayerDraggable.coffee
+++ b/framer/LayerDraggable.coffee
@@ -531,7 +531,7 @@ class exports.LayerDraggable extends BaseClass
 		return unless @_simulation
 
 		# Round the end position to whole pixels
-		@layer[axis] = parseInt(@layer[axis]) if @pixelAlign
+		@layer[axis] = Math.round(@layer[axis]) if @pixelAlign
 
 		# See if both simulators are stopped
 		if @_simulation.x.finished() and @_simulation.y.finished()

--- a/framer/LayerDraggable.coffee
+++ b/framer/LayerDraggable.coffee
@@ -249,8 +249,8 @@ class exports.LayerDraggable extends BaseClass
 
 		# Align every drag to pixels
 		if @pixelAlign
-			point.x = parseInt(point.x) if @horizontal
-			point.y = parseInt(point.y) if @vertical
+			point.x = Math.round(point.x) if @horizontal
+			point.y = Math.round(point.y) if @vertical
 
 		# While we update the layer position ourselves, we don't want
 		# to trigger the updater for external changes.


### PR DESCRIPTION
A colleague recently discovered a bug that caused draggable layers with constraints to incorrectly animate to a slightly different position than specified. The bug can be reproduced using the following code: https://gist.github.com/daneden/f5a0826168ea9626af3091d5b08c7911

Dragging the layer `myCard` up causes it to return to position `y: 89` instead of `y: 90`. This PR addresses the issue by using `Math.round` instead of `parseInt` to ensure the layer is returned to the correct constraint.

```js
> parseInt(8.999)
  8
> Math.round(8.999)
  9
```