### PR TITLE
Gradient Tests

### DIFF
--- a/framer/Animation.coffee
+++ b/framer/Animation.coffee
@@ -278,7 +278,7 @@ class exports.Animation extends BaseClass
 		for k, v of @_stateB
 			if Color.isColorObject(v) or Color.isColorObject(@_stateA[k])
 				@_valueUpdaters[k] = @_updateColorValue
-			else if Gradient.isGradient(v) or Gradient.isGradient(@_stateA[k])
+			else if Gradient.isGradientObject(v) or Gradient.isGradientObject(@_stateA[k])
 				@_valueUpdaters[k] = @_updateGradientValue
 			else
 				@_valueUpdaters[k] = @_updateNumberValue
@@ -307,7 +307,7 @@ class exports.Animation extends BaseClass
 		return _.pick(@layer, _.keys(@properties))
 
 	@isAnimatable = (v) ->
-		_.isNumber(v) or _.isFunction(v) or isRelativeProperty(v) or Color.isColorObject(v) or Gradient.isGradient(v)
+		_.isNumber(v) or _.isFunction(v) or isRelativeProperty(v) or Color.isColorObject(v) or Gradient.isGradientObject(v)
 
 	@filterAnimatableProperties = (properties) ->
 		# Function to filter only animatable properties out of a given set

--- a/framer/Animation.coffee
+++ b/framer/Animation.coffee
@@ -331,7 +331,7 @@ class exports.Animation extends BaseClass
 			else if Color.isValidColorProperty(k, v)
 				animatableProperties[k] = new Color(v)
 			else if k is "gradient" and not _.isEmpty(Gradient._asPlainObject(v))
-				animatableProperties[k] = new Gradient(v)
+				animatableProperties[k] = v
 
 		return animatableProperties
 

--- a/framer/Gradient.coffee
+++ b/framer/Gradient.coffee
@@ -78,5 +78,12 @@ class exports.Gradient extends BaseClass
 		equalEnd = Color.equal(gradientA.end, gradientB.end)
 		return equalAngle and equalStart and equalEnd
 
+	@multiplyAlpha: (gradient, alpha) ->
+		gradient = new Gradient(gradient) if not @isGradientObject(gradient)
+		return new Gradient
+			start: gradient.start.multiplyAlpha(alpha)
+			end: gradient.end.multiplyAlpha(alpha)
+			angle: gradient.angle
+
 	@_asPlainObject: (gradient) ->
 		_.pick(gradient, ["start", "end", "angle"])

--- a/framer/Gradient.coffee
+++ b/framer/Gradient.coffee
@@ -68,7 +68,9 @@ class exports.Gradient extends BaseClass
 			end: colorB
 			angle: Math.random() * 360
 
-	@isGradient: (gradient) -> return gradient instanceof Gradient
+	@isGradient: (gradient) -> return not _.isEmpty(@_asPlainObject(gradient))
+
+	@isGradientObject: (gradient) -> return gradient instanceof Gradient
 
 	@equal: (gradientA, gradientB) ->
 		return false unless Gradient.isGradient(gradientA)

--- a/framer/Gradient.coffee
+++ b/framer/Gradient.coffee
@@ -5,8 +5,6 @@
 class exports.Gradient extends BaseClass
 	constructor: (options = {}) ->
 
-		if options instanceof Gradient then return options
-
 		options.start ?= "black"
 		options.end ?= "white"
 		options.angle ?= 0

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -972,15 +972,11 @@ class exports.Layer extends BaseClass
 		get: ->
 			return layerProxiedValue(@image, @, "gradient") if Gradient.isGradientObject(@image)
 			return null
-		set: (value) ->
-			if Gradient.isGradientObject(value)
-				@image = value
+		set: (value) -> # Copy semantics!
+			if Gradient.isGradient(value)
+				@image = new Gradient(value)
 			else if not value and Gradient.isGradientObject(@image)
 				@image = null
-			else
-				gradientOptions = Gradient._asPlainObject(value)
-				if not _.isEmpty(gradientOptions)
-					@image = new Gradient(gradientOptions)
 
 	##############################################################
 	## HIERARCHY

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -95,6 +95,9 @@ class ReSetterProxy
 			Object.defineProperty(proxy, prop, desc)
 		proxy.__proto__ = target.__proto__
 
+# Use this to wrap property values in a Proxy so setting sub-properties
+# will also trigger updates on the layer.
+# Because we’re not fully on ES6, we can’t use Proxy, so use our own wrapper.
 layerProxiedValue = (value, layer, property) ->
 	return value unless _.isObject(value)
 	new ReSetterProxy value, (proxiedValue, subProperty, subValue) ->

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -16,6 +16,7 @@ Utils = require "./Utils"
 {LayerDraggable} = require "./LayerDraggable"
 {LayerPinchable} = require "./LayerPinchable"
 {Gestures} = require "./Gestures"
+{LayerPropertyProxy} = require "./LayerPropertyProxy"
 
 NoCacheDateKey = Date.now()
 
@@ -79,28 +80,12 @@ layerProperty = (obj, name, cssProperty, fallback, validator, transformer, optio
 
 exports.layerProperty = layerProperty
 
-class ReSetterProxy
-	constructor: (target, callback) ->
-		proxy = @
-		getter = (prop) ->
-			@[prop]
-		setter = (prop, value) ->
-			callback(@, prop, value, proxy)
-		for prop in Object.getOwnPropertyNames(target)
-			targetDesc = Object.getOwnPropertyDescriptor(target, prop)
-			desc =
-				enumerable: target.enumerable
-				get: getter.bind(target, prop)
-				set: setter.bind(target, prop)
-			Object.defineProperty(proxy, prop, desc)
-		proxy.__proto__ = target.__proto__
-
 # Use this to wrap property values in a Proxy so setting sub-properties
 # will also trigger updates on the layer.
 # Because we’re not fully on ES6, we can’t use Proxy, so use our own wrapper.
 layerProxiedValue = (value, layer, property) ->
 	return value unless _.isObject(value)
-	new ReSetterProxy value, (proxiedValue, subProperty, subValue) ->
+	new LayerPropertyProxy value, (proxiedValue, subProperty, subValue) ->
 		proxiedValue[subProperty] = subValue
 		layer[property] = proxiedValue
 

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -115,20 +115,21 @@ asBorderRadius = (value) ->
 	return 0 if not _.isObject(value)
 
 	result = {}
+	isValidObject = false
 	for key in ["topLeft", "topRight", "bottomRight", "bottomLeft"]
-		# TODO: Also support percentages?
-		if _.has(value, key) and _.isNumber(value[key])
-			result[key] = value[key]
-	return if _.isEmpty(result) then 0 else result
+		isValidObject ||= _.has(value, key)
+		result[key] = value[key] ? 0
+	return if not isValidObject then 0 else result
 
 asBorderWidth = (value) ->
 	return value if _.isNumber(value)
 	return 0 if not _.isObject(value)
 	result = {}
+	isValidObject = false
 	for key in ["left", "right", "bottom", "top"]
-		if _.has(value, key) and _.isNumber(value[key])
-			result[key] = value[key]
-	return if _.isEmpty(result) then 0 else result
+		isValidObject ||= _.has(value, key)
+		result[key] = value[key] ? 0
+	return if not isValidObject then 0 else result
 
 parentOrContext = (layerOrContext) ->
 	if layerOrContext.parent?

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -902,7 +902,7 @@ class exports.Layer extends BaseClass
 			defaults = Defaults.getDefaults "Layer", {}
 			isBackgroundColorDefault = @backgroundColor?.isEqual(defaults.backgroundColor)
 
-			if Gradient.isGradient(value)
+			if Gradient.isGradientObject(value)
 				@emit("change:gradient", value, currentValue)
 				@emit("change:image", value, currentValue)
 				@_setPropertyValue("image", value)
@@ -970,10 +970,10 @@ class exports.Layer extends BaseClass
 
 	@define "gradient",
 		get: ->
-			return layerProxiedValue(@image, @, "gradient") if Gradient.isGradient(@image)
+			return layerProxiedValue(@image, @, "gradient") if Gradient.isGradientObject(@image)
 			return null
 		set: (value) ->
-			if Gradient.isGradient(value)
+			if Gradient.isGradientObject(value)
 				@image = value
 			else
 				gradientOptions = Gradient._asPlainObject(value)

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -975,6 +975,8 @@ class exports.Layer extends BaseClass
 		set: (value) ->
 			if Gradient.isGradientObject(value)
 				@image = value
+			else if not value and Gradient.isGradientObject(@image)
+				@image = null
 			else
 				gradientOptions = Gradient._asPlainObject(value)
 				if not _.isEmpty(gradientOptions)

--- a/framer/LayerPropertyProxy.coffee
+++ b/framer/LayerPropertyProxy.coffee
@@ -1,0 +1,19 @@
+# This is a subset polyfill for ES6’s Proxy
+# Because we only use it for setters, the only callback available is when
+# a (sub)property is set.
+
+class exports.LayerPropertyProxy
+	constructor: (target, callback) ->
+		proxy = @
+		getter = (prop) ->
+			@[prop]
+		setter = (prop, value) ->
+			callback(@, prop, value, proxy)
+		for prop in Object.getOwnPropertyNames(target)
+			targetDesc = Object.getOwnPropertyDescriptor(target, prop)
+			desc =
+				enumerable: target.enumerable
+				get: getter.bind(target, prop)
+				set: setter.bind(target, prop)
+			Object.defineProperty(proxy, prop, desc)
+		proxy.__proto__ = target.__proto__

--- a/test/tests/GradientTest.coffee
+++ b/test/tests/GradientTest.coffee
@@ -1,4 +1,4 @@
-describe "Linear Gradient", ->
+describe "Gradient", ->
 
 	it "should allow input as object", ->
 
@@ -14,7 +14,7 @@ describe "Linear Gradient", ->
 		gradient.start.isEqual(start).should.be.true
 		gradient.end.isEqual(end).should.be.true
 		gradient.angle.should.equal angle
-	
+
 	it "should compare for equality", ->
 
 		gradient = new Gradient

--- a/test/tests/LayerAnimationTest.coffee
+++ b/test/tests/LayerAnimationTest.coffee
@@ -841,3 +841,29 @@ describe "LayerAnimation", ->
 				animation.on Events.AnimationEnd, ->
 					layer.x.should.equal 10
 					done()
+
+	describe "Gradients", ->
+
+		it "should animate only the subproperties", (done) ->
+			layer = new Layer
+			layer.gradient =
+				start: "blue"
+			layer.states.test =
+				gradient:
+					end: "red"
+			animation = layer.animate "test"
+			animation.on Events.AnimationEnd, ->
+				layer.gradient.start.isEqual("blue").should.be.true
+				layer.gradient.end.isEqual("red").should.be.true
+				done()
+
+		it "should animate if no gradient is set yet", (done) ->
+			layer = new Layer
+			layer.on "change:gradient", ->
+				layer.gradient.start.alpha.should.equal 0
+				layer.gradient.end.alpha.should.equal 0
+				done()
+			layer.animate
+				gradient:
+					start: "blue"
+					end: "red"

--- a/test/tests/LayerAnimationTest.coffee
+++ b/test/tests/LayerAnimationTest.coffee
@@ -860,10 +860,22 @@ describe "LayerAnimation", ->
 		it "should animate if no gradient is set yet", (done) ->
 			layer = new Layer
 			layer.on "change:gradient", ->
-				layer.gradient.start.alpha.should.equal 0
-				layer.gradient.end.alpha.should.equal 0
+				if layer.gradient
+					layer.gradient.start.b.should.equal 255
+			layer.on Events.AnimationEnd, ->
+				layer.gradient.start.isEqual("blue").should.be.true
 				done()
 			layer.animate
 				gradient:
 					start: "blue"
+
+		it "should animate to a null gradient", (done) ->
+			layer = new Layer
+				gradient:
+					start: "blue"
 					end: "red"
+			layer.on Events.AnimationEnd, ->
+				assert.equal layer.gradient, null
+				done()
+			layer.animate
+				gradient: null

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -608,14 +608,14 @@ describe "Layer", ->
 			borderRadius = {topLeft: 100}
 			layer.borderRadius = borderRadius
 			borderRadius.bottomRight = 100
-			expect(layer.borderRadius.bottomRight).to.equal undefined
+			expect(layer.borderRadius.bottomRight).to.equal 0
 
 		it "should copy borderWidth when set with an object", ->
 			layer = new Layer
 			borderWidth = {top: 100}
 			layer.borderWidth = borderWidth
 			borderWidth.bottom = 100
-			expect(layer.borderWidth.bottom).to.equal undefined
+			expect(layer.borderWidth.bottom).to.equal 0
 
 		it "should copy gradients when set with an object", ->
 			layer = new Layer
@@ -625,7 +625,7 @@ describe "Layer", ->
 			gradient.start = "yellow"
 			layer.gradient.start.isEqual("blue").should.be.true
 
-		it "should set sub-properties of borderRadius", ->
+		it.skip "should set sub-properties of borderRadius", ->
 			layer = new Layer
 				borderRadius: {topLeft: 100}
 			layer.borderRadius.bottomRight = 100
@@ -634,7 +634,7 @@ describe "Layer", ->
 			layer.style["border-top-left-radius"].should.equal "100px"
 			layer.style["border-bottom-right-radius"].should.equal "100px"
 
-		it "should set sub-properties of borderWidth", ->
+		it.skip "should set sub-properties of borderWidth", ->
 			layer = new Layer
 				borderWidth: {top: 100}
 			layer.borderWidth.bottom = 100
@@ -643,7 +643,7 @@ describe "Layer", ->
 			layer.style["border-top-width"].should.equal "100px"
 			layer.style["border-bottom-width"].should.equal "100px"
 
-		it "should set sub-properties of gradients", ->
+		it.skip "should set sub-properties of gradients", ->
 			layer = new Layer
 				gradient:
 					start: "blue"

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -600,7 +600,7 @@ describe "Layer", ->
 			layer.gradient.angle.should.equal(0)
 			layer.style["background-image"].should.equal("linear-gradient(0deg, rgb(255, 255, 0), rgb(128, 0, 128))")
 
-			layer.gradent = null
+			layer.gradient = null
 			layer.style["background-image"].should.equal("")
 
 		it "should copy borderRadius when set with an object", ->

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -608,14 +608,14 @@ describe "Layer", ->
 			borderRadius = {topLeft: 100}
 			layer.borderRadius = borderRadius
 			borderRadius.bottomRight = 100
-			expect(layer.borderRadius.bottomRight).to.equal 0
+			layer.borderRadius.bottomRight.should.equal 0
 
 		it "should copy borderWidth when set with an object", ->
 			layer = new Layer
 			borderWidth = {top: 100}
 			layer.borderWidth = borderWidth
 			borderWidth.bottom = 100
-			expect(layer.borderWidth.bottom).to.equal 0
+			layer.borderWidth.bottom.should.equal 0
 
 		it "should copy gradients when set with an object", ->
 			layer = new Layer
@@ -625,7 +625,7 @@ describe "Layer", ->
 			gradient.start = "yellow"
 			layer.gradient.start.isEqual("blue").should.be.true
 
-		it.skip "should set sub-properties of borderRadius", ->
+		it "should set sub-properties of borderRadius", ->
 			layer = new Layer
 				borderRadius: {topLeft: 100}
 			layer.borderRadius.bottomRight = 100
@@ -634,16 +634,16 @@ describe "Layer", ->
 			layer.style["border-top-left-radius"].should.equal "100px"
 			layer.style["border-bottom-right-radius"].should.equal "100px"
 
-		it.skip "should set sub-properties of borderWidth", ->
+		it "should set sub-properties of borderWidth", ->
 			layer = new Layer
-				borderWidth: {top: 100}
-			layer.borderWidth.bottom = 100
-			layer.borderWidth.top.should.equal(100)
-			layer.borderWidth.bottom.should.equal(100)
-			layer.style["border-top-width"].should.equal "100px"
-			layer.style["border-bottom-width"].should.equal "100px"
+				borderWidth: {top: 10}
+			layer.borderWidth.bottom = 10
+			layer.borderWidth.top.should.equal(10)
+			layer.borderWidth.bottom.should.equal(10)
+			layer._elementBorder.style["border-top-width"].should.equal "10px"
+			layer._elementBorder.style["border-bottom-width"].should.equal "10px"
 
-		it.skip "should set sub-properties of gradients", ->
+		it "should set sub-properties of gradients", ->
 			layer = new Layer
 				gradient:
 					start: "blue"

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -582,6 +582,26 @@ describe "Layer", ->
 			layer.htmlIntrinsicSize = null
 			assert.equal layer.htmlIntrinsicSize, null
 
+		it "should set gradient", ->
+			layer = new Layer
+			layer.gradient = new Gradient
+				start: "blue"
+				end: "red"
+				angle: 42
+			layer.gradient.start.isEqual("blue").should.be.true
+			layer.gradient.end.isEqual("red").should.be.true
+			layer.gradient.angle.should.equal(42)
+			layer.style["background-image"].should.equal("linear-gradient(42deg, rgb(0, 0, 255), rgb(255, 0, 0))")
+
+			layer.gradient =
+				start: "yellow"
+				end: "purple"
+			layer.gradient.angle.should.equal(0)
+			layer.style["background-image"].should.equal("linear-gradient(0deg, rgb(255, 255, 0), rgb(128, 0, 128))")
+
+			layer.gradent = null
+			layer.style["background-image"].should.equal("")
+
 	describe "Filter Properties", ->
 
 		it "should set nothing on defaults", ->

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -1,4 +1,5 @@
 assert = require "assert"
+{expect} = require "chai"
 simulate = require "simulate"
 
 describe "Layer", ->
@@ -601,6 +602,55 @@ describe "Layer", ->
 
 			layer.gradent = null
 			layer.style["background-image"].should.equal("")
+
+		it "should copy borderRadius when set with an object", ->
+			layer = new Layer
+			borderRadius = {topLeft: 100}
+			layer.borderRadius = borderRadius
+			borderRadius.bottomRight = 100
+			expect(layer.borderRadius.bottomRight).to.equal undefined
+
+		it "should copy borderWidth when set with an object", ->
+			layer = new Layer
+			borderWidth = {top: 100}
+			layer.borderWidth = borderWidth
+			borderWidth.bottom = 100
+			expect(layer.borderWidth.bottom).to.equal undefined
+
+		it "should copy gradients when set with an object", ->
+			layer = new Layer
+			gradient = new Gradient
+				start: "blue"
+			layer.gradient = gradient
+			gradient.start = "yellow"
+			layer.gradient.start.isEqual("blue").should.be.true
+
+		it "should set sub-properties of borderRadius", ->
+			layer = new Layer
+				borderRadius: {topLeft: 100}
+			layer.borderRadius.bottomRight = 100
+			layer.borderRadius.topLeft.should.equal(100)
+			layer.borderRadius.bottomRight.should.equal(100)
+			layer.style["border-top-left-radius"].should.equal "100px"
+			layer.style["border-bottom-right-radius"].should.equal "100px"
+
+		it "should set sub-properties of borderWidth", ->
+			layer = new Layer
+				borderWidth: {top: 100}
+			layer.borderWidth.bottom = 100
+			layer.borderWidth.top.should.equal(100)
+			layer.borderWidth.bottom.should.equal(100)
+			layer.style["border-top-width"].should.equal "100px"
+			layer.style["border-bottom-width"].should.equal "100px"
+
+		it "should set sub-properties of gradients", ->
+			layer = new Layer
+				gradient:
+					start: "blue"
+			layer.gradient.end = "yellow"
+			layer.gradient.start.isEqual("blue").should.be.true
+			layer.gradient.end.isEqual("yellow").should.be.true
+			layer.style["background-image"].should.equal("linear-gradient(0deg, rgb(0, 0, 255), rgb(255, 255, 0))")
 
 	describe "Filter Properties", ->
 

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -455,63 +455,6 @@ describe "Layer", ->
 				layer.x = "hello"
 			f.should.throw()
 
-		it "should set borderRadius", ->
-
-			testBorderRadius = (layer, value) ->
-
-				if layer.style["border-top-left-radius"] is "#{value}"
-					layer.style["border-top-left-radius"].should.equal "#{value}"
-					layer.style["border-top-right-radius"].should.equal "#{value}"
-					layer.style["border-bottom-left-radius"].should.equal "#{value}"
-					layer.style["border-bottom-right-radius"].should.equal "#{value}"
-				else
-					layer.style["border-top-left-radius"].should.equal "#{value} #{value}"
-					layer.style["border-top-right-radius"].should.equal "#{value} #{value}"
-					layer.style["border-bottom-left-radius"].should.equal "#{value} #{value}"
-					layer.style["border-bottom-right-radius"].should.equal "#{value} #{value}"
-
-			layer = new Layer
-
-			layer.borderRadius = 10
-			layer.borderRadius.should.equal 10
-
-			testBorderRadius(layer, "10px")
-
-			layer.borderRadius = "50%"
-			layer.borderRadius.should.equal "50%"
-
-			testBorderRadius(layer, "50%")
-
-		it "should set borderRadius with objects", ->
-
-			testBorderRadius = (layer, tl, tr, bl, br) ->
-
-				layer.style["border-top-left-radius"].should.equal "#{tl}"
-				layer.style["border-top-right-radius"].should.equal "#{tr}"
-				layer.style["border-bottom-left-radius"].should.equal "#{bl}"
-				layer.style["border-bottom-right-radius"].should.equal "#{br}"
-
-			layer = new Layer
-
-			# No matching keys is an error
-			layer.borderRadius = {aap: 10, noot: 20, mies: 30}
-			layer.borderRadius.should.equal 0
-			testBorderRadius(layer, "0px", "0px", "0px", "0px")
-
-			# Arrays are not supported either
-			layer.borderRadius = [1, 2, 3, 4]
-			layer.borderRadius.should.equal 0
-			testBorderRadius(layer, "0px", "0px", "0px", "0px")
-
-			layer.borderRadius = {topLeft: 10}
-			layer.borderRadius.topLeft.should.equal 10
-			testBorderRadius(layer, "10px", "0px", "0px", "0px")
-
-			layer.borderRadius = {topLeft: 1, topRight: 2, bottomLeft: 3, bottomRight: 4}
-			layer.borderRadius.topLeft.should.equal 1
-			layer.borderRadius.bottomRight.should.equal 4
-			testBorderRadius(layer, "1px", "2px", "3px", "4px")
-
 		it "should set perspective", ->
 
 			layer = new Layer
@@ -583,74 +526,137 @@ describe "Layer", ->
 			layer.htmlIntrinsicSize = null
 			assert.equal layer.htmlIntrinsicSize, null
 
-		it "should set gradient", ->
-			layer = new Layer
-			layer.gradient = new Gradient
-				start: "blue"
-				end: "red"
-				angle: 42
-			layer.gradient.start.isEqual("blue").should.be.true
-			layer.gradient.end.isEqual("red").should.be.true
-			layer.gradient.angle.should.equal(42)
-			layer.style["background-image"].should.equal("linear-gradient(42deg, rgb(0, 0, 255), rgb(255, 0, 0))")
+		describe "Border Radius", ->
 
-			layer.gradient =
-				start: "yellow"
-				end: "purple"
-			layer.gradient.angle.should.equal(0)
-			layer.style["background-image"].should.equal("linear-gradient(0deg, rgb(255, 255, 0), rgb(128, 0, 128))")
+			it "should set borderRadius", ->
 
-			layer.gradient = null
-			layer.style["background-image"].should.equal("")
+				testBorderRadius = (layer, value) ->
 
-		it "should copy borderRadius when set with an object", ->
-			layer = new Layer
-			borderRadius = {topLeft: 100}
-			layer.borderRadius = borderRadius
-			borderRadius.bottomRight = 100
-			layer.borderRadius.bottomRight.should.equal 0
+					if layer.style["border-top-left-radius"] is "#{value}"
+						layer.style["border-top-left-radius"].should.equal "#{value}"
+						layer.style["border-top-right-radius"].should.equal "#{value}"
+						layer.style["border-bottom-left-radius"].should.equal "#{value}"
+						layer.style["border-bottom-right-radius"].should.equal "#{value}"
+					else
+						layer.style["border-top-left-radius"].should.equal "#{value} #{value}"
+						layer.style["border-top-right-radius"].should.equal "#{value} #{value}"
+						layer.style["border-bottom-left-radius"].should.equal "#{value} #{value}"
+						layer.style["border-bottom-right-radius"].should.equal "#{value} #{value}"
 
-		it "should copy borderWidth when set with an object", ->
-			layer = new Layer
-			borderWidth = {top: 100}
-			layer.borderWidth = borderWidth
-			borderWidth.bottom = 100
-			layer.borderWidth.bottom.should.equal 0
+				layer = new Layer
 
-		it "should copy gradients when set with an object", ->
-			layer = new Layer
-			gradient = new Gradient
-				start: "blue"
-			layer.gradient = gradient
-			gradient.start = "yellow"
-			layer.gradient.start.isEqual("blue").should.be.true
+				layer.borderRadius = 10
+				layer.borderRadius.should.equal 10
 
-		it "should set sub-properties of borderRadius", ->
-			layer = new Layer
-				borderRadius: {topLeft: 100}
-			layer.borderRadius.bottomRight = 100
-			layer.borderRadius.topLeft.should.equal(100)
-			layer.borderRadius.bottomRight.should.equal(100)
-			layer.style["border-top-left-radius"].should.equal "100px"
-			layer.style["border-bottom-right-radius"].should.equal "100px"
+				testBorderRadius(layer, "10px")
 
-		it "should set sub-properties of borderWidth", ->
-			layer = new Layer
-				borderWidth: {top: 10}
-			layer.borderWidth.bottom = 10
-			layer.borderWidth.top.should.equal(10)
-			layer.borderWidth.bottom.should.equal(10)
-			layer._elementBorder.style["border-top-width"].should.equal "10px"
-			layer._elementBorder.style["border-bottom-width"].should.equal "10px"
+				layer.borderRadius = "50%"
+				layer.borderRadius.should.equal "50%"
 
-		it "should set sub-properties of gradients", ->
-			layer = new Layer
-				gradient:
+				testBorderRadius(layer, "50%")
+
+			it "should set borderRadius with objects", ->
+
+				testBorderRadius = (layer, tl, tr, bl, br) ->
+
+					layer.style["border-top-left-radius"].should.equal "#{tl}"
+					layer.style["border-top-right-radius"].should.equal "#{tr}"
+					layer.style["border-bottom-left-radius"].should.equal "#{bl}"
+					layer.style["border-bottom-right-radius"].should.equal "#{br}"
+
+				layer = new Layer
+
+				# No matching keys is an error
+				layer.borderRadius = {aap: 10, noot: 20, mies: 30}
+				layer.borderRadius.should.equal 0
+				testBorderRadius(layer, "0px", "0px", "0px", "0px")
+
+				# Arrays are not supported either
+				layer.borderRadius = [1, 2, 3, 4]
+				layer.borderRadius.should.equal 0
+				testBorderRadius(layer, "0px", "0px", "0px", "0px")
+
+				layer.borderRadius = {topLeft: 10}
+				layer.borderRadius.topLeft.should.equal 10
+				testBorderRadius(layer, "10px", "0px", "0px", "0px")
+
+				layer.borderRadius = {topLeft: 1, topRight: 2, bottomLeft: 3, bottomRight: 4}
+				layer.borderRadius.topLeft.should.equal 1
+				layer.borderRadius.bottomRight.should.equal 4
+				testBorderRadius(layer, "1px", "2px", "3px", "4px")
+
+			it "should copy borderRadius when set with an object", ->
+				layer = new Layer
+				borderRadius = {topLeft: 100}
+				layer.borderRadius = borderRadius
+				borderRadius.bottomRight = 100
+				layer.borderRadius.bottomRight.should.equal 0
+
+			it "should set sub-properties of borderRadius", ->
+				layer = new Layer
+					borderRadius: {topLeft: 100}
+				layer.borderRadius.bottomRight = 100
+				layer.borderRadius.topLeft.should.equal(100)
+				layer.borderRadius.bottomRight.should.equal(100)
+				layer.style["border-top-left-radius"].should.equal "100px"
+				layer.style["border-bottom-right-radius"].should.equal "100px"
+
+		describe "Border Width", ->
+
+			it "should copy borderWidth when set with an object", ->
+				layer = new Layer
+				borderWidth = {top: 100}
+				layer.borderWidth = borderWidth
+				borderWidth.bottom = 100
+				layer.borderWidth.bottom.should.equal 0
+
+			it "should set sub-properties of borderWidth", ->
+				layer = new Layer
+					borderWidth: {top: 10}
+				layer.borderWidth.bottom = 10
+				layer.borderWidth.top.should.equal(10)
+				layer.borderWidth.bottom.should.equal(10)
+				layer._elementBorder.style["border-top-width"].should.equal "10px"
+				layer._elementBorder.style["border-bottom-width"].should.equal "10px"
+
+		describe "Gradient", ->
+
+			it "should set gradient", ->
+				layer = new Layer
+				layer.gradient = new Gradient
 					start: "blue"
-			layer.gradient.end = "yellow"
-			layer.gradient.start.isEqual("blue").should.be.true
-			layer.gradient.end.isEqual("yellow").should.be.true
-			layer.style["background-image"].should.equal("linear-gradient(0deg, rgb(0, 0, 255), rgb(255, 255, 0))")
+					end: "red"
+					angle: 42
+				layer.gradient.start.isEqual("blue").should.be.true
+				layer.gradient.end.isEqual("red").should.be.true
+				layer.gradient.angle.should.equal(42)
+				layer.style["background-image"].should.equal("linear-gradient(42deg, rgb(0, 0, 255), rgb(255, 0, 0))")
+
+				layer.gradient =
+					start: "yellow"
+					end: "purple"
+				layer.gradient.angle.should.equal(0)
+				layer.style["background-image"].should.equal("linear-gradient(0deg, rgb(255, 255, 0), rgb(128, 0, 128))")
+
+				layer.gradient = null
+				layer.style["background-image"].should.equal("")
+
+			it "should copy gradients when set with an object", ->
+				layer = new Layer
+				gradient = new Gradient
+					start: "blue"
+				layer.gradient = gradient
+				gradient.start = "yellow"
+				layer.gradient.start.isEqual("blue").should.be.true
+
+			it "should set sub-properties of gradients", ->
+				layer = new Layer
+					gradient:
+						start: "blue"
+				layer.gradient.end = "yellow"
+				layer.gradient.start.isEqual("blue").should.be.true
+				layer.gradient.end.isEqual("yellow").should.be.true
+				layer.style["background-image"].should.equal("linear-gradient(0deg, rgb(0, 0, 255), rgb(255, 255, 0))")
 
 	describe "Filter Properties", ->
 


### PR DESCRIPTION
Implements and adds tests for behavior such as discussed:
- Animate sub properties of gradients
- Animate from/to `null` gradients
- Copy/value semantics when setting object values on `borderRadius`, `borderWidth` and `gradient` properties
- Ability to set subproperties of those properies directly via layer.

Because `Proxy` is ES6, I implemented a bit more minimal proxy class, looking at Proxy polyfills.

Questions:
- Does it work as expected?
- Is the code OK?
- Should the ReSetterProxy be more minimal?
- Where should the ReSetterProxy go?