### PR TITLE
Path animation

### DIFF
--- a/framer/SVG.coffee
+++ b/framer/SVG.coffee
@@ -1,0 +1,78 @@
+{BaseClass} = require "./BaseClass"
+
+class SVG
+	@isSVG: (svg) ->
+		svg instanceof SVGElement
+
+	@hasSinglePath: (svg) ->
+		return false if not @isSVG(svg)
+		svg.children.length is 1 and exports.SVGPath.isPath(svg.children[0])
+
+	@getPath: (svg) ->
+		return null if not @hasSinglePath(svg)
+		return svg.children[0]
+
+
+class SVGPath extends BaseClass
+
+	@define "length",
+		get: ->
+			@_length
+
+
+	@define "start",
+		get: ->
+			@pointAtFraction(0)
+
+	@define "end",
+		get: ->
+			@pointAtFraction(0)
+
+	@define "path", @simpleProperty("path", null)
+
+	constructor: (path) ->
+		return null if not SVGPath.isPath(path)
+		super
+		if path instanceof SVGPath
+			path = path.path
+		@path = path
+		@_length = path.getTotalLength()
+
+	pointAtFraction: (fraction) ->
+		@path.getPointAtLength(@length * fraction)
+
+	valueUpdater: (axis, target, offset) =>
+		switch axis
+			when "horizontal"
+				offset -= @start.x
+				return (key, value) =>
+					target[key] = offset + @pointAtFraction(value).x
+			when "vertical"
+				offset -= @start.y
+				return (key, value) =>
+					target[key] = offset + @pointAtFraction(value).y
+			when "angle"
+				return (key, value, delta = 0) =>
+					return if delta is 0
+					fromPoint = @pointAtFraction(Math.max(value - delta, 0))
+					toPoint = @pointAtFraction(Math.min(value + delta, 1))
+					angle = Math.atan2(fromPoint.y - toPoint.y, fromPoint.x - toPoint.x) * 180 / Math.PI - 90
+					target[key] = angle
+
+	@isPath: (path) ->
+		path instanceof SVGPathElement or path instanceof SVGPath
+
+	@getStart: (path) ->
+		@getPointAtFraction(path, 0)
+
+	@getPointAtFraction: (path, fraction) ->
+		return null if not @isPath(path)
+		length = path.getTotalLength() * fraction
+		path.getPointAtLength(length)
+
+	@getEnd: (path) ->
+		@getPointAtFraction(path, 1)
+
+
+exports.SVG = SVG
+exports.SVGPath = SVGPath

--- a/framer/SVG.coffee
+++ b/framer/SVG.coffee
@@ -4,15 +4,6 @@ class SVG
 	@isSVG: (svg) ->
 		svg instanceof SVGElement
 
-	@hasSinglePath: (svg) ->
-		return false if not @isSVG(svg)
-		svg.children.length is 1 and exports.SVGPath.isPath(svg.children[0])
-
-	@getPath: (svg) ->
-		return null if not @hasSinglePath(svg)
-		return svg.children[0]
-
-
 class SVGPath extends BaseClass
 
 	@define "length",

--- a/framer/SVG.coffee
+++ b/framer/SVG.coffee
@@ -4,6 +4,7 @@ class SVG
 	@isSVG: (svg) ->
 		svg instanceof SVGElement
 
+
 class SVGPath extends BaseClass
 
 	@define "length",

--- a/framer/SVG.coffee
+++ b/framer/SVG.coffee
@@ -17,7 +17,7 @@ class SVGPath extends BaseClass
 
 	@define "end",
 		get: ->
-			@pointAtFraction(0)
+			@pointAtFraction(1)
 
 	@define "path", @simpleProperty("path", null)
 

--- a/framer/SVGLayer.coffee
+++ b/framer/SVGLayer.coffee
@@ -60,11 +60,19 @@ class exports.SVGLayer extends Layer
 
 	@define "path",
 		get: ->
-			if @svg.children.length isnt 1
-				throw new Error("SVGLayer.path can only be used on SVG's that have a single child")
+			if @svg.children?.length isnt 1
+				error = "SVGLayer.path can only be used on SVG's that have a single child"
+				if Utils.isFramerStudio()
+					throw new Error(error)
+				else
+					console.error(error)
 			child = @svg.children[0]
 			if not SVGPath.isPath(child)
-				throw new Error("SVGLayer.path can only be used on SVG's containing an SVGPathElement, not #{Utils.inspectObjectType(child)}")
+				error = "SVGLayer.path can only be used on SVG's containing an SVGPathElement, not #{Utils.inspectObjectType(child)}"
+				if Utils.isFramerStudio()
+					throw new Error(error)
+				else
+					console.error(error)
 			return child
 
 	@define "pathStart",

--- a/framer/SVGLayer.coffee
+++ b/framer/SVGLayer.coffee
@@ -60,7 +60,12 @@ class exports.SVGLayer extends Layer
 
 	@define "path",
 		get: ->
-			SVG.getPath(@svg)
+			if @svg.children.length isnt 1
+				throw new Error("SVGLayer.path can only be used on SVG's that have a single child")
+			child = @svg.children[0]
+			if not SVGPath.isPath(child)
+				throw new Error("SVGLayer.path can only be used on SVG's containing an SVGPathElement, not #{Utils.inspectObjectType(child)}")
+			return child
 
 	@define "pathStart",
 		get: ->

--- a/framer/SVGLayer.coffee
+++ b/framer/SVGLayer.coffee
@@ -1,6 +1,7 @@
 {_} = require "./Underscore"
 {Color} = require "./Color"
 {Layer, layerProperty, layerProxiedValue} = require "./Layer"
+{SVG, SVGPath} = require "./SVG"
 
 validFill = (value) ->
 	Color.validColorValue(value) or _.startsWith(value, "url(")
@@ -10,6 +11,7 @@ toFill = (value) ->
 		return value
 	else
 		return Color.toColor(value)
+
 class exports.SVGLayer extends Layer
 
 	constructor: (options={}) ->
@@ -55,6 +57,19 @@ class exports.SVGLayer extends Layer
 				if value.parentNode?
 					value = value.cloneNode(true)
 				@_elementHTML.appendChild(value)
+
+	@define "path",
+		get: ->
+			SVG.getPath(@svg)
+
+	@define "pathStart",
+		get: ->
+			start = SVGPath.getStart(@path)
+			return null if not start?
+			point =
+				x: @x + start.x
+				y: @y + start.y
+			return point
 
 	updateGradientSVG: ->
 		return if @__constructor


### PR DESCRIPTION
This is basically a really light-weight re-implementation of https://github.com/koenbok/Framer/pull/151.

Here's an example: https://framer.cloud/RiKaw

The API is as follows:
```coffee

wave = new SVGLayer
	width: 762
	height: 470
	point: 100
	backgroundColor: null
	html: '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="762" height="470"><path id="shape-id-a6lZkKiUM" d="M 0 470 C 126.91666666666663 470 126.91666666666663 0 253.83333333333331 0 C 380.75 0 380.75 470 507.66666666666663 470 C 634.5833333333333 470 634.5833333333334 0 761.5 0" transform="translate(0.5 0) rotate(0.0000 380.75 235)" fill="transparent" stroke-width="1" stroke="#AAA" stroke-linecap="butt" stroke-linejoin="miter" stroke-dasharray="10" stroke-dashoffset="0" stroke-miterlimit="4"></path></svg>'

path = wave.path
triangle.originY = 0
triangle.midX = wave.pathStart.x
triangle.y = wave.pathStart.y
triangle.animate
	point: path
	rotation: path
	options: 
		time: 10
```

I've added a `path` property to SVG layer that only returns an SVG path if it's the only child of the svg. This is a bit limiting, but hopefully makes the API a bit clearer