### PR TITLE
remove layers from the DOMEventManager

### DIFF
--- a/framer/DOMEventManager.coffee
+++ b/framer/DOMEventManager.coffee
@@ -3,7 +3,7 @@
 
 Utils = require "./Utils"
 
-EventManagerIdCounter = 0
+EventManagerIdCounter = 1
 
 class DOMEventManagerElement extends EventEmitter
 
@@ -41,6 +41,11 @@ class exports.DOMEventManager
 			@_elements[element._eventManagerId] = new DOMEventManagerElement(element)
 
 		@_elements[element._eventManagerId]
+
+	remove: (element) =>
+		return unless element._eventManagerId
+		delete @_elements[element._eventManagerId]
+		element._eventManagerId = 0
 
 	reset: ->
 		for element, elementEventManager of @_elements

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -958,6 +958,7 @@ class exports.Layer extends BaseClass
 
 		@_context.removeLayer(@)
 		@_context.emit("layer:destroy", @)
+		@_context.domEventManager.remove(@_element)
 
 
 	##############################################################

--- a/test/tests/LayerTest.coffee
+++ b/test/tests/LayerTest.coffee
@@ -1558,11 +1558,15 @@ describe "Layer", ->
 
 		it "should destroy", ->
 
+			before = Object.keys(Framer.CurrentContext.domEventManager._elements).length
+
 			layer = new Layer
 			layer.destroy()
 
 			(layer in Framer.CurrentContext.layers).should.be.false
 			assert.equal layer._element.parentNode, null
+
+			assert.equal before, Object.keys(Framer.CurrentContext.domEventManager._elements).length
 
 		it "should set text", ->
 


### PR DESCRIPTION
`Layer._element`s were never removed from the `DOMEventManager` thus leaking a lot of dom nodes and `DOMEventManagerElement` (which are `EventEmitter`s).

Especially relevant for projects that use layers for particles or such.