### PR TITLE
Copy children with constraintValues when using Layer.copy

### DIFF
--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -995,10 +995,12 @@ class exports.Layer extends BaseClass
 	copy: ->
 
 		layer = @copySingle()
-
+		
 		for child in @_children
 			copiedChild = child.copy()
-			copiedChild.parent = layer if copiedChild isnt null
+			if copiedChild
+				copiedChild.parent = layer
+				copiedChild.constraintValues = child.constraintValues
 
 		return layer
 

--- a/framer/Layer.coffee
+++ b/framer/Layer.coffee
@@ -993,9 +993,8 @@ class exports.Layer extends BaseClass
 	## COPYING
 
 	copy: ->
-
 		layer = @copySingle()
-		
+
 		for child in @_children
 			copiedChild = child.copy()
 			if copiedChild


### PR DESCRIPTION
This preserves constraintValues of a layer's children when copying the layer via `layer.copy()`. See [Issue 581](https://github.com/koenbok/Framer/issues/581).